### PR TITLE
Fix macOS compiler flags for OpenMP

### DIFF
--- a/boltzmann/class/class_v2.4.1/Makefile
+++ b/boltzmann/class/class_v2.4.1/Makefile
@@ -33,12 +33,7 @@ OPTFLAG = -fPIC -O4 -ffast-math -fno-tree-vectorize
 #OPTFLAG = -Ofast -ffast-math #-march=native
 #OPTFLAG = -fast
 
-# your openmp flag (comment for compiling without openmp)
-ifeq (${COSMOSIS_OMP},1)
-OMPFLAG   = -fopenmp
-endif
-#OMPFLAG   = -mp -mp=nonuma -mp=allcores -g
-#OMPFLAG   = -openmp
+# OpenMP flags are already handled by ${COSMOSIS_SRC_DIR}/config/compilers.mk
 
 # all other compilation flags
 #CCFLAG = -g -fPIC

--- a/likelihood/planck2018/plc-3.0/Makefile
+++ b/likelihood/planck2018/plc-3.0/Makefile
@@ -77,15 +77,7 @@ COLORS = 1
 #set echo to echo -e to have colourized output on some shell
 ECHO = echo 
 
-
-#COPENMP =
-ifeq (${COSMOSIS_OMP},1)
-# what is the openmp option for your C compiler (leave empty to compile without openmp)
-COPENMP = -fopenmp
-# what is the openmp option for your F90 compiler (leave empty to cmpile without openmp)
-FOPENMP = -fopenmp
-LDOMP = -fopenmp
-endif
+# OpenMP flags are already handled by ${COSMOSIS_SRC_DIR}/config/compilers.mk
 
 # what is the 32/64 bit option for your C compiler (leave empty if you don't want to know)
 CM64 =


### PR DESCRIPTION
This changes the build of a few libraries that could use OpenMP to do so on macOS, using the Apple Clang compiler. This requires using the flags `-Xpreprocessor -fopenmp`, rather than just `-fopenmp`. 

It also converts a couple of files from DOS to Unix line endings.