### PR TITLE
Fix cblas gsl import on NERSC

### DIFF
--- a/structure/projection/projection_tools/gsl_wrappers.py
+++ b/structure/projection/projection_tools/gsl_wrappers.py
@@ -23,13 +23,20 @@ def find_gsl():
 def load_gsl(libfile=None):
     if libfile is None:
         try:
-            libfile, _ = find_gsl()
+            libfile, cblas_libfile = find_gsl()
         except ValueError:
             libfile = "libgsl.so"
+    # This isn't always necessary, but it is on NERSC
+    # To help debug I'll leave this lib1 variable here.
     try:
+        lib1 = ct.CDLL(cblas_libfile, mode=ct.RTLD_GLOBAL)
+    except OSError:
+        lib1 = None
+    try:
+        # Try loading the CBLAS file first. Sometimes this is needed.
         gsl = ct.CDLL(libfile, mode=ct.RTLD_GLOBAL)
     except OSError as err:
-        msg = str(err) + " ** If you are using conda you might need to source cosmosis-configure **"
+        msg = f"{err} ** If you are using conda you might need to source cosmosis-configure, or otherwise you may need to set up GSL differently. **"
         raise OSError(msg) from err
     return gsl
 


### PR DESCRIPTION
This is the ongoing thing with cblas and gsl. As far as I can tell libgsl.so should link to libgsl_cblass.so, but doesn't sometimes. But that could be my hazy understanding, possibly should just be linking differently.  But this works at NERSC at least