### PR TITLE
Fix setting parameters for mead2020 and mead2020_feedback

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -260,10 +260,14 @@ def extract_initial_power_params(block, config, more_config):
     return init_power
 
 def extract_nonlinear_params(block, config, more_config):
-    if 'mead' in more_config["nonlinear_params"].get('halofit_version', ''):
+    version = more_config["nonlinear_params"].get('halofit_version', '')
+    if version == "mead2015" or version == "mead2016":
         A = block[names.halo_model_parameters, 'A']
         eta0 = block[names.halo_model_parameters, "eta"]
         hmcode_params = {"HMCode_A_baryon": A, "HMCode_eta_baryon":eta0}
+    elif version == "mead2020_feedback":
+        T_AGN = block[names.halo_model_parameters, 'logT_AGN']
+        hmcode_params = {"HMCode_logT_AGN": T_AGN}
     else:
         hmcode_params = {}
 

--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -261,7 +261,8 @@ def extract_initial_power_params(block, config, more_config):
 
 def extract_nonlinear_params(block, config, more_config):
     version = more_config["nonlinear_params"].get('halofit_version', '')
-    if version == "mead2015" or version == "mead2016":
+
+    if version == "mead2015" or version == "mead2016" or version == "mead":
         A = block[names.halo_model_parameters, 'A']
         eta0 = block[names.halo_model_parameters, "eta"]
         hmcode_params = {"HMCode_A_baryon": A, "HMCode_eta_baryon":eta0}


### PR DESCRIPTION
Addresses [cosmosis issue 39](https://github.com/joezuntz/cosmosis/issues/39).

@jessmuir has pointed out that setting mead2020 in camb required parameters to be set that were not in fact used, and mead2020_feedback did not read the one useful parameter.

I think, from reading the camb docs and code, that these parameters need to be set:
- `mead2015`, `mead2016`: `HMCode_eta_baryon` and `HMCode_A_baryon`
- `mead2020`: none
- `mead2020_feedback`: `HMCode_logT_AGN`

`mead` is an alias for `mead2016`. 
