### PR TITLE
Stop class assuming that CC=gcc

### DIFF
--- a/boltzmann/class/class_v3.2.0/python/setup.py
+++ b/boltzmann/class/class_v3.2.0/python/setup.py
@@ -7,15 +7,17 @@ import os
 import subprocess as sbp
 import os.path as osp
 
+cc = os.environ.get("CC", "gcc")
+
 # Recover the gcc compiler
 GCCPATH_STRING = sbp.Popen(
-    ['gcc', '-print-libgcc-file-name'],
+    [cc, '-print-libgcc-file-name'],
     stdout=sbp.PIPE).communicate()[0]
 GCCPATH = osp.normpath(osp.dirname(GCCPATH_STRING)).decode()
 
 liblist = ["class"]
 MVEC_STRING = sbp.Popen(
-    ['gcc', '-lmvec'],
+    [cc, '-lmvec'],
     stderr=sbp.PIPE).communicate()[1]
 if b"mvec" not in MVEC_STRING:
     liblist += ["mvec","m"]


### PR DESCRIPTION
Class does a test for a library while assuming that the path to the C compiler is called `gcc`. This isn't always true, and the difference means some processes can fail at NERSC. This makes it use the environment CC if present, otherwise falls back to `gcc`.