### PR TITLE
Restore the option to save the kernels used in the Limber integral to the block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         shell: bash -l {0}
         run: |
           source cosmosis-configure
-          cosmosis examples/des-y3.ini | tee output/des-y3.log
+          cosmosis examples/des-y3.ini -p pk_to_cl_gg.save_kernels=T pk_to_cl.save_kernels=T | tee output/des-y3.log
           grep 'Likelihood =  6043.23' output/des-y3.log
 
       - name: Euclid emulator

--- a/structure/projection/module.yaml
+++ b/structure/projection/module.yaml
@@ -89,8 +89,8 @@ params:
         meaning: Raise an error instead of returning non-zero on error loading splines. Handy for debugging.
         type: bool
         default: false
-    get_kernel_peaks:
-        meaning: Save peak positions for the computed kernels
+    save_kernels:
+        meaning: Save the kernels n(chi) and w(chi) to the block
         type: bool
         default: false
     do_exact:
@@ -225,6 +225,25 @@ inputs:
             type: real 1d
             default:
 outputs:
+    kernel_{sample}:
+        n_of_chi_chi_{i}:
+            meaning: The chi values for the n(chi) calculation. Only if save_kernels=T.
+            type: real 1d
+        n_of_chi_n_{i}:
+            meaning: The n values for the n(chi) calculation. Only if save_kernels=T.
+            type: real 1d
+        w_of_chi_chi_{i}:
+            meaning: The chi values for the w(chi) calculation. Only if save_kernels=T and shear spectrum calculated.
+            type: real 1d
+        w_of_chi_n_{i}:
+            meaning: The n values for the w(chi) calculation. Only if save_kernels=T and shear spectrum calculated.
+            type: real 1d
+        ww_of_chi_chi_{i}:
+            meaning: The chi values for the ww(chi) calculation. Only if save_kernels=T and Weyl spectrum calculated.
+            type: real 1d
+        ww_of_chi_n_{i}:
+            meaning: The n values for the ww(chi) calculation. Only if save_kernels=T and Weyl spectrum calculated.
+            type: real 1d
     shear_cl:
         nbin_a:
             meaning: Number of tomographic bins for first of the two quantities correlated.

--- a/structure/projection/project_2d.py
+++ b/structure/projection/project_2d.py
@@ -1166,7 +1166,7 @@ class SpectrumCalculator(object):
         self.verbose = options.get_bool(option_section, "verbose", False)
         self.fatal_errors = options.get_bool(option_section, "fatal_errors", False)
         self.get_kernel_peaks = options.get_bool(option_section, "get_kernel_peaks", False)
-        self.save_kernel_zmax = options.get_double(option_section, "save_kernel_zmax", -1.0)
+        self.save_kernels = options.get_bool(option_section, "save_kernels", False)
 
         self.limber_ell_start = options.get_int(option_section, "limber_ell_start", 300)
         do_exact_string = options.get_string(option_section, "do_exact", "")
@@ -1502,6 +1502,11 @@ class SpectrumCalculator(object):
             else:
                 raise ValueError(f"Invalid kernel type: {kernel_type}. Should be 'N' or 'W'")
 
+    def save_kernels_to_block(self, block):
+        for name, kernel in self.kernels.items():
+            section = f"kernels_{name}"
+            kernel.to_block(block, section)
+
     def load_power(self, block):
         # Loop through keys in self.req_power_keys, initializing the Power3d
         # instances and adding to the self.power dictionary.
@@ -1628,8 +1633,8 @@ class SpectrumCalculator(object):
             # We can optionally save the kernels that go into the
             # integration as well.  This is useful for e.g. plotting
             # things.  Thi
-            if self.save_kernel_zmax > 0:
-                self.save_kernels(block, self.save_kernel_zmax)
+            if self.save_kernels:
+                self.save_kernels_to_block(block)
 
             # Load the P(k)s
             t0 = timer()

--- a/structure/projection/projection_tools/kernel.py
+++ b/structure/projection/projection_tools/kernel.py
@@ -126,6 +126,18 @@ class TomoNzKernel(object):
             nzs.append(nz)
         return cls(z, nzs, norm=norm)
 
+    def to_block(self, block, section):
+        for b, spline in self.nchi_splines.items():
+            block[section, f"n_of_chi_chi_{b}"] = spline.x
+            block[section, f"n_of_chi_n_{b}"] = spline.y
+        for b, spline in self.wchi_splines.items():
+            block[section, f"w_of_chi_chi_{b}"] = spline.x
+            block[section, f"w_of_chi_n_{b}"] = spline.y
+        for b, spline in self.wwchi_splines.items():
+            block[section, f"ww_of_chi_chi_{b}"] = spline.x
+            block[section, f"ww_of_chi_n_{b}"] = spline.y
+
+
     def set_nofchi_splines(self, chi_of_z, dchidz, clip=1.e-6):
         chi = chi_of_z(self.z)
         dchidz = dchidz(self.z)


### PR DESCRIPTION
This adds the boolean `save_kernels` option to the project_2d module.  Unlike the old version we now just save the entire kernel, and leave it as n(chi) and w(chi) instead of converting to z.

Addresses issue #30 