### PR TITLE
save CDM+baryon linear power spectrum

### DIFF
--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -147,14 +147,20 @@ def get_class_outputs(block, c, config):
     if 'mPk' in c.pars['output']:
         block[cosmo, 'sigma_8'] = c.sigma8()
 
+        # Total matter power spectrum
         P = np.zeros((k.size, z.size))
         for i, ki in enumerate(k):
             for j, zi in enumerate(z):
                 P[i, j] = c.pk_lin(ki, zi)
-
         # Save matter power as a grid
         block.put_grid("matter_power_lin", "k_h", k / h0, "z", z, "p_k", P * h0**3)
 
+        # CDM+baryons power spectrum
+        P = np.zeros((k.size, z.size))
+        for i, ki in enumerate(k):
+            for j, zi in enumerate(z):
+                P[i, j] = c.pk_cb_lin(ki, zi)
+        block.put_grid('cdm_baryon_power_lin', 'k_h', k/h0, 'z', z, 'p_k', P*h0**3)
 
         # Get growth rates and sigma_8
         D = [c.scale_independent_growth_factor(zi) for zi in z]

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -43,6 +43,8 @@ def setup(options):
         'lensing': options.get_bool(option_section, 'lensing', default=True),
         'cmb': options.get_bool(option_section, 'cmb', default=True),
         'mpk': options.get_bool(option_section, 'mpk', default=True),
+        'save_matter_power_lin': options.get_bool(option_section, 'save_matter_power_lin', default=True),
+        'save_cdm_baryon_power_lin': options.get_bool(option_section, 'save_cdm_baryon_power_lin', default=False),
     }
 
 
@@ -147,20 +149,21 @@ def get_class_outputs(block, c, config):
     if 'mPk' in c.pars['output']:
         block[cosmo, 'sigma_8'] = c.sigma8()
 
-        # Total matter power spectrum
-        P = np.zeros((k.size, z.size))
-        for i, ki in enumerate(k):
-            for j, zi in enumerate(z):
-                P[i, j] = c.pk_lin(ki, zi)
-        # Save matter power as a grid
-        block.put_grid("matter_power_lin", "k_h", k / h0, "z", z, "p_k", P * h0**3)
+        # Total matter power spectrum (saved as grid)
+        if config['save_matter_power_lin']:
+            P = np.zeros((k.size, z.size))
+            for i, ki in enumerate(k):
+                for j, zi in enumerate(z):
+                    P[i, j] = c.pk_lin(ki, zi)
+            block.put_grid("matter_power_lin", "k_h", k / h0, "z", z, "p_k", P * h0**3)
 
         # CDM+baryons power spectrum
-        P = np.zeros((k.size, z.size))
-        for i, ki in enumerate(k):
-            for j, zi in enumerate(z):
-                P[i, j] = c.pk_cb_lin(ki, zi)
-        block.put_grid('cdm_baryon_power_lin', 'k_h', k/h0, 'z', z, 'p_k', P*h0**3)
+        if config['save_cdm_baryon_power_lin']:
+            P = np.zeros((k.size, z.size))
+            for i, ki in enumerate(k):
+                for j, zi in enumerate(z):
+                    P[i, j] = c.pk_cb_lin(ki, zi)
+            block.put_grid('cdm_baryon_power_lin', 'k_h', k/h0, 'z', z, 'p_k', P*h0**3)
 
         # Get growth rates and sigma_8
         D = [c.scale_independent_growth_factor(zi) for zi in z]


### PR DESCRIPTION
So far, the class interface allows to store the total (linear) matter power spectrum. However, there are applications like the halo mass function where the power spectrum of CDM+baryons is needed. The camb interface already allows to store the cdm+baryons linear power spectrum, this PR allows to do the same for class (using the same variable name `cdm_baryon_power_lin`). Thanks also to @asmaamaz