### PR TITLE
Fixes for MacOS OpenMP (v2)

### DIFF
--- a/likelihood/planck2018/plc-3.0/Makefile
+++ b/likelihood/planck2018/plc-3.0/Makefile
@@ -77,15 +77,7 @@ COLORS = 1
 #set echo to echo -e to have colourized output on some shell
 ECHO = echo 
 
-
-#COPENMP =
-ifeq (${COSMOSIS_OMP},1)
-# what is the openmp option for your C compiler (leave empty to compile without openmp)
-COPENMP = -fopenmp
-# what is the openmp option for your F90 compiler (leave empty to cmpile without openmp)
-FOPENMP = -fopenmp
-LDOMP = -fopenmp
-endif
+# OpenMP flags are already handled by ${COSMOSIS_SRC_DIR}/config/compilers.mk
 
 # what is the 32/64 bit option for your C compiler (leave empty if you don't want to know)
 CM64 =


### PR DESCRIPTION
This is a new version of Marc's changes in #7 with merges to apply to the newest version of class (which had these fixes already). This also led to finding a problem with the compiler flags.

People might need to update to cosmosis 2.1.5 if they update to this version of the CSL (should be in conda forge shortly).  New installations will pick that up automatically.
