### PR TITLE
Catch the camb error "dark energy model has w + wa > 0, giving w>0 at high redshift"

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -569,10 +569,10 @@ def save_cls(r, p, block):
 
 def execute(block, config):
     config, more_config = config
-    p = extract_camb_params(block, config, more_config)
-    
 
     try:
+        p = extract_camb_params(block, config, more_config)
+
         if (not p.WantCls) and (not p.WantTransfer):
             # Background only mode
             r = camb.get_background(p)

--- a/boltzmann/class/class_v3.2.0/Makefile
+++ b/boltzmann/class/class_v3.2.0/Makefile
@@ -47,7 +47,10 @@ OPTFLAG = -O3
 #OMPFLAG   = -openmp
 
 # all other compilation flags
-CCFLAG = -g -fPIC $(CFLAGS) -std=gnu99
+# JAZ - added GSL here not because it actually needs GSL but
+# with conda it forces the compiler to find omp.h. I don't
+# understand why this only recently stopped working.
+CCFLAG = -g -fPIC $(CFLAGS) -std=gnu99  -I ${GSL_INC}
 LDFLAG = -g -fPIC $(CFLAGS)
 
 # leave blank to compile without HyRec, or put path to HyRec directory


### PR DESCRIPTION
CAMB sometimes raises the above error, and because it happens when setting initial parameters instead of when getting results this can currently propagate up and crash chains. 

This moves extract_camb_params inside the same try/except as the main results so such parameter combinations should be rejected.

It might catch other similar errors too.