### PR TITLE
Fix camb f(z) calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         pyversion: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout repository
@@ -149,7 +149,7 @@ jobs:
 
 
   apt-get-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]


### PR DESCRIPTION
There is something wrong with the cosmosis interpolation of f(z) in camb. Probably I messed up the ordering or something. This switches to use camb's internal (f * sigma_8) / sigma_8. (There is no camb function to calculate f directly).

Also updating the CI to specify ubuntu 20.04 explicitly.

Addresses cosmosis issue [#59 ](https://github.com/joezuntz/cosmosis/issues/59)
