### PR TITLE
Class version of DES Y3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
           cosmosis examples/des-y3.ini -p pk_to_cl_gg.save_kernels=T pk_to_cl.save_kernels=T | tee output/des-y3.log
           grep 'Likelihood =  6043.23' output/des-y3.log
 
+      - name: DES Y3 Class likelihood
+        shell: bash -l {0}
+        run: |
+          source cosmosis-configure
+          cosmosis examples/des-y3-class.ini
+          # class is not consistent across systems to the level needed here
+
       - name: DES Y3 cosmic shear likelihood
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           activate-environment: cosmosis-env
           channels: conda-forge
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           python-version: ${{ matrix.pyversion }}
 
       - name: Install dependencies with conda

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -216,6 +216,10 @@ def get_class_outputs(block, c, config):
     block[distances, 'age'] = c.age()
     block[distances, 'rs_zdrag'] = c.rs_drag()
 
+    # Save H(z), which is also in Mpc^-1 units, like in camb
+    h_z = np.array([c.Hubble(zi) for zi in z])
+    block[distances, 'H'] = h_z
+
     ##
     # Now the CMB C_ell
     ##

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -155,7 +155,8 @@ def get_class_outputs(block, c, config):
             for i, ki in enumerate(k):
                 for j, zi in enumerate(z):
                     P[i, j] = c.pk_lin(ki, zi)
-            block.put_grid("matter_power_lin", "k_h", k / h0, "z", z, "p_k", P * h0**3)
+            # We transpose P here to match the camb convention
+            block.put_grid("matter_power_lin", "z", z, "k_h", k / h0, "p_k", P.T * h0**3)
 
         # CDM+baryons power spectrum
         if config['save_cdm_baryon_power_lin']:
@@ -163,7 +164,7 @@ def get_class_outputs(block, c, config):
             for i, ki in enumerate(k):
                 for j, zi in enumerate(z):
                     P[i, j] = c.pk_cb_lin(ki, zi)
-            block.put_grid('cdm_baryon_power_lin', 'k_h', k/h0, 'z', z, 'p_k', P*h0**3)
+            block.put_grid('cdm_baryon_power_lin', 'z', z, 'k_h', k/h0, 'p_k', P.T * h0 **3)
 
         # Get growth rates and sigma_8
         D = [c.scale_independent_growth_factor(zi) for zi in z]
@@ -182,7 +183,7 @@ def get_class_outputs(block, c, config):
                 for j, zi in enumerate(z):
                     P[i, j] = c.pk(ki, zi)
 
-            block.put_grid("matter_power_nl", "k_h", k / h0, "z", z, "p_k", P * h0**3)
+            block.put_grid("matter_power_nl", "z", z, "k_h", k / h0, "p_k", P.T * h0**3)
 
 
     ##
@@ -191,6 +192,7 @@ def get_class_outputs(block, c, config):
 
     # save redshifts of samples
     block[distances, 'z'] = z
+    block[distances, 'a'] = 1 / (1 + z)
     block[distances, 'nz'] = nz
 
     # Save distance samples

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -39,6 +39,7 @@ def setup(options):
         'lmax': options.get_int(option_section, 'lmax', default=2000),
         'zmax': options.get_double(option_section, 'zmax', default=3.0),
         'kmax': options.get_double(option_section, 'kmax', default=50.0),
+        'nk': options.get_int(option_section, 'nk', default=100),
         'debug': options.get_bool(option_section, 'debug', default=False),
         'lensing': options.get_bool(option_section, 'lensing', default=True),
         'cmb': options.get_bool(option_section, 'cmb', default=True),
@@ -87,8 +88,19 @@ def get_class_inputs(block, config):
         'T_cmb':     block.get_double(cosmo, 'TCMB', default=2.726),
         'N_ur':      nnu - nmassive,
         'N_ncdm':    nmassive,
-        'm_ncdm':    block.get_double(cosmo, 'mnu', default=0.06)
     }
+
+
+    neutrino_mass_total = block.get_double(cosmo, 'mnu', default=0.06)
+    if nmassive == 0:
+        if neutrino_mass_total == 0.06:
+            assert neutrino_mass_total == 0, f"mnu must equal 0 when num_massive_neutrinos=0, but you had {neutrino_mass_total} - you may have left it at the default value"
+        else:
+            assert neutrino_mass_total == 0, f"mnu must equal 0 when num_massive_neutrinos=0, but you had {neutrino_mass_total}"
+    else:
+        neutrino_masses = np.repeat(neutrino_mass_total / nmassive, nmassive).astype(str)
+        params['m_ncdm'] = ", ".join(neutrino_masses)
+
 
     if config["cmb"] or config["lensing"]:
         params.update({
@@ -116,7 +128,6 @@ def get_class_inputs(block, config):
         if key.startswith('class_'):
             params[key[6:]] = val
 
-
     return params
 
 
@@ -137,7 +148,7 @@ def get_class_outputs(block, c, config):
     dz = 0.01
     kmin = 1e-4
     kmax = config['kmax'] * h0
-    nk = 100
+    nk = config["nk"]
 
     # Define k,z we want to sample
     z = np.arange(0.0, config["zmax"] + dz, dz)

--- a/examples/des-y3-class-values.ini
+++ b/examples/des-y3-class-values.ini
@@ -1,0 +1,66 @@
+[cosmological_parameters]
+omega_m      =  0.1     0.3     0.9
+h0           =  0.55    0.69    0.91
+omega_b      =  0.03    0.048   0.07
+n_s          =  0.87    0.97    1.07
+A_s          =  0.5e-09 2.19e-9 5.0e-09
+w            =  -1.0
+
+; Old parameter names from original cosmosis version
+; omnuh2       =  0.0006  0.00083 0.00644
+; massive_nu   =  3
+; massless_nu  =  0.046
+
+; New parametrization and names:
+mnu = 0.06
+num_massive_neutrinos = 3
+nnu = 3.046
+
+omega_k      =  0.0
+tau          =  0.0697186
+
+[shear_calibration_parameters]
+m1 = -0.1  0.0  0.1
+m2 = -0.1  0.0  0.1 
+m3 = -0.1  0.0  0.1
+m4 = -0.1  0.0  0.1
+
+[wl_photoz_errors]
+bias_1 = -0.1   0.0   0.1
+bias_2 = -0.1   0.0   0.1
+bias_3 = -0.1   0.0   0.1
+bias_4 = -0.1   0.0   0.1
+
+[lens_photoz_errors]
+bias_1 = -0.05  0.0  0.05
+bias_2 = -0.05  0.0  0.05
+bias_3 = -0.05  0.0  0.05
+bias_4 = -0.05  0.0  0.05
+bias_5 = -0.05  0.0  0.05
+width_1 = 1.0
+width_2 = 1.0
+width_3 = 1.0
+width_4 = 1.0
+width_5 = 0.1 1.0 1.9
+
+[bias_lens]
+b1 = 0.8  1.7   3.0
+b2 = 0.8  1.7   3.0
+b3 = 0.8  1.7   3.0
+b4 = 0.8  2.0   3.0
+b5 = 0.8  2.0   3.0
+
+[mag_alpha_lens]
+alpha_1 =  1.31
+alpha_2 = -0.52
+alpha_3 =  0.34
+alpha_4 =  2.25
+alpha_5 =  1.97
+
+[intrinsic_alignment_parameters]
+z_piv   =  0.62
+A1      = -5.0   0.7  5.0
+A2      = -5.0  -1.36 5.0 
+alpha1  = -5.0  -1.7  5.0
+alpha2  = -5.0  -2.5  5.0
+bias_ta =  0.0   1.0  2.0

--- a/examples/des-y3-class.ini
+++ b/examples/des-y3-class.ini
@@ -1,0 +1,37 @@
+%include examples/des-y3.ini
+
+
+[pipeline]
+modules =  consistency  bbn_consistency
+           class  extrapolate
+           fast_pt
+           fits_nz  lens_photoz_width  lens_photoz_bias  source_photoz_bias
+           IA  pk_to_cl_gg  pk_to_cl
+           add_magnification  add_intrinsic
+           2pt_shear 2pt_gal  2pt_gal_shear
+           shear_m_bias   add_point_mass
+           2pt_like  shear_ratio_like
+
+values = examples/des-y3-class-values.ini
+
+[test]
+save_dir = output/des-y3-class
+
+[extrapolate]
+file = boltzmann/extrapolate/extrapolate_power.py
+power_spectra_names = matter_power_nl matter_power_lin
+npoint = 10
+kmax = 500.0
+
+[class]
+file = boltzmann/class/class_interface.py
+version = 3.2.0
+lmax = 2850
+debug = T
+zmax = 4.0
+kmax = 100.0
+nk = 700
+cmb = T
+mpk = T
+lensing = T
+class_non_linear = halofit

--- a/structure/fast_pt/fast_pt_interface.py
+++ b/structure/fast_pt/fast_pt_interface.py
@@ -93,8 +93,11 @@ def execute(block, config):
     need_reinit = False
     lin = names.matter_power_lin
     nl = names.matter_power_nl
-    k0 = block[lin, "k_h"]
-    knl1 = block[nl, "k_h"]
+
+    z, k0, Pkz = block.get_grid(lin, "z", "k_h", "P_k")
+    znl, knl1, Pkznl = block.get_grid(nl, "z", "k_h", "P_k")
+
+
     # note that extension, if needed, must be done on Plin at every step.
     if config['always_init']:
         need_reinit = True
@@ -116,17 +119,12 @@ def execute(block, config):
     
     k0log=np.log(k0)
     knl1log=np.log(knl1)
-    Pkz = block[lin, "P_k"]
-    Pkznl = block[nl, "P_k"]
     P0 = Pkz[0,:]
     ind=np.where(k0>0.03)[0][0]
     #note minor scale-dependence in growth factor.
     ##use z values from linear CAMB
-    z = block[lin, "z"]
     Growth2 = Pkz[:,ind]/Pkz[0,ind]
 
-    ##use z values from halofit (typically the same as lin)
-    znl = block[nl, "z"]
     #Growth2 = Pkznl[:,ind]/Pkz[0,ind]
     #test that nl and lin have same z values
     msg='lin and nl power spectra are calculated at different z values.'

--- a/structure/projection/projection_tools/gsl_wrappers.py
+++ b/structure/projection/projection_tools/gsl_wrappers.py
@@ -26,6 +26,7 @@ def load_gsl(libfile=None):
             libfile, cblas_libfile = find_gsl()
         except ValueError:
             libfile = "libgsl.so"
+            cblas_libfile = "libgslcblas.so"
     # This isn't always necessary, but it is on NERSC
     # To help debug I'll leave this lib1 variable here.
     try:


### PR DESCRIPTION
Fixes to allow CLASS in DES y3
- Alters the class P(k) output, flipping k and z, to make it consistent with camb
- Adds the "a" output which was missing from class distances
- Have fast_pt use get_grid so it doesn't care about the ordering
- Fix class massive nu handling, though it's still different assumptions to camb
- Fixes a bug with an error message being very opaque