### PR TITLE
Faster and better-named distance calculations in camb and astropy modules

### DIFF
--- a/background/astropy_background/astropy_background.py
+++ b/background/astropy_background/astropy_background.py
@@ -87,13 +87,30 @@ def execute(block, config):
 	#Calculate distances
 	z = np.linspace(0.0, zmax, nz)
 	a = 1/(1.+z)
+
+	# comoving radial
+	D_C = model.comoving_distance(z).to_value(astropy.units.Mpc)
+	Ok0 = model._Ok0
+
+	# comoving transverse
+	if Ok0 == 0:
+		D_M = D_C
+	else:
+		sqrtOk0 = np.sqrt(abs(Ok0))
+		dh = model._hubble_distance.value
+		if Ok0 > 0:
+			D_M = dh / sqrtOk0 * np.sinh(sqrtOk0 * D_C / dh)
+		else:
+			D_M = dh / sqrtOk0 * np.sin(sqrtOk0 * D_C / dh)
+
+	D_L = D_M * (1 + z)
+	D_A = D_M / (1 + z)
 	mu = np.zeros(z.size)
 	mu[0] = -np.inf
-	mu[1:] = model.distmod(z[1:])
-	D_L = model.luminosity_distance(z).to_value(astropy.units.Mpc)
-	D_A = model.angular_diameter_distance(z).to_value(astropy.units.Mpc)
-	D_M = model.comoving_distance(z).to_value(astropy.units.Mpc)
+	mu[1:] = 5.0 * np.log10(D_L[1:]) + 25.0	
+
 	H_z = (model.H(z) / astropy.constants.c).to_value(1/astropy.units.Mpc)
+	D_V = ((1 + z)**2 * z * D_A**2 / H_z )**(1./3.)
 
 
 	#Save results
@@ -102,11 +119,13 @@ def execute(block, config):
 	block[names.distances, "mu"] = mu
 	block[names.distances, "D_L"] = D_L
 	block[names.distances, "D_A"] = D_A
+	block[names.distances, "D_V"] = D_V
 	block[names.distances, "D_M"] = D_M
+	block[names.distances, "D_C"] = D_C
 	block[names.distances, "H"] = H_z
 
 	# Save the units in the metadata as well
-	for name in ("D_L", "D_A", "D_M"):
+	for name in ("D_L", "D_A", "D_M", "D_C", "D_V"):
 		block.put_metadata(names.distances, name, "unit", "Mpc")
 	block.put_metadata(names.distances, "H", "unit", "1.0/Mpc")
 

--- a/demos/demo5.ini
+++ b/demos/demo5.ini
@@ -77,6 +77,7 @@ tolerance = 1e-6
 file = boltzmann/camb/camb_interface.py
 mode = background
 feedback = 0
+do_bao=F
 
 ; We need quite fine redshift spacing, because the supernovae
 ; go down to low z where things are pretty sensitive


### PR DESCRIPTION
This speeds up the calculations when doing b/g-only calculations in the camb and astropy modules.
It also changes the output naming slightly for curved models: D_M is now actually D_M and D_C is actually D_C. This matches what was in cosmosis v1.0; it was an error that it was different in v2.

Unless you're using some custom modules this will only have caused problems if you're doing some specific BAO things with curved models. In flat models there was no difference.