### PR TITLE
Adding manual bin division options for smail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           python -m cosmosis.configure
           source cosmosis-configure
           export
-          mkdir output
+          mkdir -p output
           # Check the downloader works
           ./examples/get-planck-data.sh
           # And that the pipeline runs afterwards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
           source cosmosis-configure
           make
 
+      - name: Smail example
+        shell: bash -l {0}
+        run: |
+          source cosmosis-configure
+          cosmosis examples/various-spectra.ini
+
       - name: CAMB Planck
         shell: bash -l {0}
         run: |

--- a/examples/various-spectra-values.ini
+++ b/examples/various-spectra-values.ini
@@ -1,0 +1,52 @@
+
+; Parameters and data in CosmoSIS are organized into sections
+; so we can easily see what they mean.
+[cosmological_parameters]
+
+; These parameters are pretty much always required
+; for cosmology, though you sometimes just fix omega_b
+omega_m = 0.31
+h0 = 0.67
+omega_b = 0.049
+
+; Tau (optical depth) is only needed if you need
+; the thermal history, or the CMB/matter power
+tau = 0.0925
+
+; These ones are only needed if you are doing CMB or matter
+; power data, not if you just want thermal history or background
+; evolution
+n_s = 0.962
+A_s = 2.1e-9
+sigma8_input = 0.81
+
+; These parameters can affect everything but are not required -
+; if they are not found in this file they take the sensible
+; default values shown here
+omega_k = 0.0
+w = -1.0
+wa = 0.0
+
+[galaxy_bias]
+alpha = 2.23
+b0 = 0.79
+c = 0.57
+
+[number_density_params]
+alpha = 2.0
+beta = 1.0
+z0 = 0.5
+sigz = 0.05
+ngal = 20
+bias = 0.0
+
+; For the constant bias model:
+;b = 1.0
+
+
+
+; [ggl_xi]
+; ggl_amplitude_1 = 1.0 500.0 900.0
+; ggl_amplitude_2 = 1.0 500.0 900.0
+; ggl_amplitude_3 = 1.0 500.0 900.0
+

--- a/examples/various-spectra.ini
+++ b/examples/various-spectra.ini
@@ -1,0 +1,175 @@
+; Demonstrate the different angular two-point functions in the standard library
+[runtime]
+sampler = test
+
+[test]
+save_dir=output/various-spectra
+fatal_errors=T
+
+[pipeline]
+modules = consistency dndz luminosity_slope camb  clerkin_bias angular_power 2pt_shear 2pt_matter 2pt_ggl 2pt_mag 2pt_map 2pt_nap 2pt_map_nap
+values = examples/various-spectra-values.ini
+; Not used here, becuase we are not sampling
+likelihoods =
+extra_output =
+quiet=F
+debug=T
+timing=F
+
+; The consistency module translates between our chosen parameterization
+; and any other that modules in the pipeline may want (e.g. camb)
+[consistency]
+file = ./utility/consistency/consistency_interface.py
+
+[camb]
+file = ./boltzmann/camb/camb_interface.py
+mode=all
+lmax=2500
+nz_background = 301
+zmax_background = 3.1
+feedback=3
+halofit_version = takahashi
+
+; new simple module for using sigma8 as an input instead of A_s
+; the only parameter required is the file location
+[sigma8_rescale]
+file = ./utility/sample_sigma8/sigma8_rescale.py
+
+; Works the same as halofit but uses the Takahashi non-linear correction
+[halofit_takahashi]
+file = ./boltzmann/halofit_takahashi/halofit_interface.so
+
+; use a Smail distribution for the underlying z values
+[dndz]
+file = ./number_density/smail/photometric_smail.py
+nbin = 3
+zmax = 2.0
+dz = 0.01
+z_edges = 0.2  0.4  0.6  1.0
+output_section = nz_sample
+
+
+; The magnification spectrum is sensitive to the slope of the luminosity number
+; count function.  This module uses a fitting function for the slope alpha.
+[luminosity_slope]
+file = ./luminosity_function/Joachimi_Bridle_alpha/interface.py
+magnitude_limit = 24.0
+binned_alpha = T
+sample = nz_sample
+output_section = mag_alpha_sample
+
+; Our bias model reqires the growth factor D(z).
+; This module calculates that.
+[growth]
+file = ./structure/growth_factor/interface.so
+zmin = 0.0
+zmax = 3.0
+dz = 0.01
+
+; The Clerkin et al (2015) bias model.
+; The default model, "GTD" is the "Generalized Time-Dependent" model.
+; This requires three parameters which are given in the values file.
+[clerkin_bias]
+file= ./bias/clerkin/clerkin_interface.py
+
+; You could replace clerkin_bias with this constant bias module and 
+; uncomment the constant bias value in the values file if think you know bias
+; perfectly. 
+[constant_bias]
+file = ./bias/constant_bias/constant_bias.py
+
+
+
+[angular_power]
+file = ./structure/projection/project_2d.py
+ell_min_logspaced = 10.0
+ell_max_logspaced = 100000.0
+n_ell_logspaced = 100
+shear-shear = sample-sample
+position-position = sample-sample
+magnification-magnification = sample-sample
+position-shear = sample-sample
+verbose = T
+
+;other spectra you could switch on, though many of these will need additional
+;input P(k) values to be calculated first.
+; shear-Intrinsic = T
+; intrinsic-Intrinsic = T
+; magnification-Position = T
+; position-Intrinsic = T
+; magnification-Intrinsic = T
+; magnification-Shear = T
+; shear-Cmbkappa = T
+; cmbkappa-Cmbkappa = T
+; intrinsic-Cmbkappa = T
+; position-Cmbkappa = T
+
+; This module converts angular spectra from c_ell to correlation functions w(theta).
+; It is slow and can be a little dodgy at small theta, so if you have a better
+; version it would be great if you be happy to add it (or have us add it) to cosmosis
+[2pt_shear]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+; theta_min = 1.0
+; theta_max = 50.0
+; n_theta = 50
+input_section_name = shear_cl
+output_section_name = shear_xi
+; Type of Hankel transform and output correlation function
+; [0 = shear, 1 = matter, 2 = ggl]
+corr_type = 0
+
+[2pt_matter]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+; theta_min = 1.0
+; theta_max = 50.0
+; n_theta = 50
+input_section_name = galaxy_cl
+output_section_name = galaxy_xi
+; Type of Hankel transform and output correlation function
+; [0 = shear, 1 = matter, 2 = ggl]
+corr_type = 1
+
+[2pt_ggl]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+; theta_min = 1.0
+; theta_max = 50.0
+; n_theta = 50
+input_section_name = galaxy_shear_cl
+output_section_name = galaxy_shear_xi
+; Type of Hankel transform and output correlation function
+; [0 = shear, 1 = matter, 2 = ggl]
+corr_type = 2
+
+[2pt_mag]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+; theta_min = 1.0
+; theta_max = 50.0
+; n_theta = 50
+input_section_name = magnification_cl
+output_section_name = magnification_xi
+; Type of Hankel transform and output correlation function
+; [0 = shear, 1 = matter, 2 = ggl]
+corr_type = 1
+
+
+[2pt_map]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+input_section_name = shear_cl
+output_section_name = shear_map
+filter_type = 1
+corr_type = 0
+
+[2pt_map_nap]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+input_section_name = galaxy_shear_cl
+output_section_name = galaxy_shear_map_nap
+filter_type = 1
+corr_type = 2
+
+[2pt_nap]
+file = ./shear/cl_to_xi_nicaea/nicaea_interface.so
+input_section_name = galaxy_cl
+output_section_name = galaxy_nap
+filter_type = 1
+corr_type = 1
+

--- a/likelihood/2pt/twopoint.py
+++ b/likelihood/2pt/twopoint.py
@@ -424,7 +424,7 @@ class SpectrumMeasurement(object):
         header['WINDOWS'] = self.windows  # NOT YET CODED ANYTHING ELSE
         header['N_ZBIN_1'] = len(np.unique(self.bin1))
         header['N_ZBIN_2'] = len(np.unique(self.bin2))
-        if self.metadata is not None:
+        if (self.metadata is not None) and self.metadata:
             # Check metadata doesn't share any keys with the stuff that's already in the header
             assert set(self.metadata.keys()).isdisjoint(set(header.keys()))
             for key, val in self.metadata.iteritems():
@@ -490,6 +490,7 @@ class CovarianceMatrixInfo(object):
 
     def to_fits(self):
         header = fits.Header()
+        
         header[COV_SENTINEL] = True
         header['EXTNAME'] = self.name
         for i, (start_index, name) in enumerate(zip(self.starts, self.names)):

--- a/number_density/smail/module.yaml
+++ b/number_density/smail/module.yaml
@@ -34,6 +34,18 @@ params:
         meaning: Spacing of samples to compute n(z) at.
         type: real
         default:
+    enforce_equal_numbers:
+	meaning: No matter how n(z) gets divided, specify that each bin has equal number density
+        type: bool
+        default: F
+    z_edges:
+	meaning: Manually specified redshift bin edges. If nbin - 1 values passed,
+	   these are the bounds of photometric selection for those nbin bins.
+	   If 2 values are passed, they specify a minimum and maximum redshift between
+	   which galaxies are divided into equal number samples. 
+        type: real 1d
+        default: None
+    
 inputs:
     number_density_params:
         alpha:
@@ -78,3 +90,6 @@ outputs:
             meaning: The nominal edges of the redshift bins (i.e. edges if no photometric
                 errors)
             type: real 1d
+	NGAL_{}:
+	    meaning: number density of redshift bin i
+	    type: real

--- a/number_density/smail/module.yaml
+++ b/number_density/smail/module.yaml
@@ -4,7 +4,7 @@ version: 1
 purpose: Compute window functions for photometric n(z)
 url: ''
 interface: photometric_smail.py
-attribution: [CosmoSIS Team]
+attribution: [Donnacha Kirk, Simon Samuroff, Jessica Muir]
 rules: You can do what you want with this file
 cite: []
 assumptions:
@@ -19,30 +19,35 @@ explanation: |
     error sigma(z) = sigma_0 (1+z) and optionally biases it.  It computes bin edges in the
     survey assuming equal numbers in each.
 
-    We might wish to add an option to specify fixed bin edges instead?
+    You can also specify fixed bin edges.
     "
 params:
     nbin:
-        meaning: Number of redshift bins with equal number of gals in eachq
+        meaning: Number of redshift bins with equal number of gals in each
         type: int
         default:
-    zmax:
-        meaning: Maximum redshift to compute; min is zero
+    zmin:
+        meaning: Minimum redshift to compute
         type: real
-        default:
+        default: 0.0
+    zmax:
+        meaning: Maximum redshift to compute
+        type: real
+        default: 4.0
     dz:
         meaning: Spacing of samples to compute n(z) at.
         type: real
-        default:
+        default: 0.01
     enforce_equal_numbers:
-	meaning: No matter how n(z) gets divided, specify that each bin has equal number density
+        meaning: No matter how n(z) gets divided, specify that each bin has equal number density
         type: bool
         default: F
     z_edges:
-	meaning: Manually specified redshift bin edges. If nbin - 1 values passed,
-	   these are the bounds of photometric selection for those nbin bins.
-	   If 2 values are passed, they specify a minimum and maximum redshift between
-	   which galaxies are divided into equal number samples. 
+        meaning: |
+             "Manually specified redshift bin edges. If nbin - 1 values passed,
+             these are the bounds of photometric selection for those nbin bins.
+             If 2 values are passed, they specify a minimum and maximum redshift between
+             which galaxies are divided into equal number samples. "
         type: real 1d
         default: None
     
@@ -87,9 +92,8 @@ outputs:
             meaning: n(z) at redshift sample values.  bin_1, bin_2, ...
             type: real 1d
         edge_{i}:
-            meaning: The nominal edges of the redshift bins (i.e. edges if no photometric
-                errors)
+            meaning: The nominal edges of the redshift bins (i.e. edges if no photometric errors)
             type: real 1d
-	NGAL_{}:
-	    meaning: number density of redshift bin i
-	    type: real
+    NGAL_{}:
+        meaning: number density of redshift bin i
+        type: real

--- a/number_density/smail/photometric_smail.py
+++ b/number_density/smail/photometric_smail.py
@@ -1,5 +1,6 @@
 # Code by Donnacha Kirk
 # Edited by Simon Samuroff 07/2015
+# Edited by Jessie Muir 03/2023
 
 from builtins import zip
 from builtins import range
@@ -28,6 +29,7 @@ def delta(z, z0):
     return x
 
 
+
 def photometric_error(z, Nz, sigma_z, bias):
     nz = len(z)
     output = np.zeros((nz, nz))
@@ -51,14 +53,37 @@ def photometric_error(z, Nz, sigma_z, bias):
     return output
 
 
-def find_bins(z, nz_true, nbin):
+def find_bins(z, nz_true, nbin, zmin=None, zmax=None):
+    """
+    Find redshift bins with equal numbers of galaxies in them. 
+    Inputs:
+    z - redshift array
+    nz_true - array containing full n(z) distribution
+    nbin - number of bins to split that into
+    zmin - lower bound where to start divisions; defaults to min 
+           value in z array
+    zmax - lower bound where to start divisions; defaults to max
+           value in z array
+    """
+    if zmax is None:
+        zmax = z.max()
+    if zmin is not None:
+        zmin = z.min()
+    w =(z>zmin)*(z<zmax) # only sum counts in specified range
+    else:
+        zmin=0.
+        w=1.
+
+
+
+    nz_true = nz_true*w
     nz_true = nz_true / nz_true.sum() * nbin
     cum = np.cumsum(nz_true)
-    bin_edges = [0.0]
+    bin_edges = [zmin]
     for i in range(1, nbin):
         edge = np.interp(1.0 * i, cum, z)
         bin_edges.append(edge)
-    bin_edges.append(z.max())
+    bin_edges.append(zmax)
     return np.array(bin_edges)
 
 
@@ -66,6 +91,7 @@ def compute_bin_nz(z_prob_matrix, z, edges, ngal):
     NI = []
     nbin = len(edges) - 1
     dz = z[1] - z[0]
+   
     for low, high in zip(edges[:-1], edges[1:]):
         w = np.where((z > low) & (z < high))[0]
         # Sum over all possible ztrue
@@ -74,39 +100,107 @@ def compute_bin_nz(z_prob_matrix, z, edges, ngal):
 
         # Normalise the n(z) in each redshift bin to 1 over the redshift range
         # of the survey
-        ni *= 1.0 / (ni.sum() * dz)
+        ni_integral = np.trapz(ni,z)
+    
+        ni *= 1.0 / ni_integral
         assert(len(ni) == len(z))
         NI.append(ni)
-    return NI
+
+    return NI 
+
+def get_ngals_presmooth(nz_true,z,edges,ngaltot):
+    """
+    Given bin divisions, and total number of galaxies in sample
+    figure out how many galaxies are in each redshift bin. 
+
+    N.b. Evaluation done before smoothing, with the idea being
+    that you divide the sample in photo-z estimates, and then
+    the smoothing translates photo-z selection to true n(z) 
+    distributions. 
+    """
+    integrals = []
+    for low, high in zip(edges[:-1], edges[1:]):
+        w = (z>low)*(z<high)
+        wnz = w*nz_true
+        integrals.append(np.trapz(wnz,z))
+    integrals = np.array(integrals)
+    inttot = integrals.sum()
+    ngal_fracs = integrals/inttot
+    ngalvals = ngaltot*ngal_fracs
+    return ngalvals
 
 
 def smail_distribution(z, alpha, beta, z0):
     return (z**alpha) * np.exp(-(z / z0)**beta)
 
 
-def compute_nz(alpha, beta, z0, z, nbin, sigma_z, ngal, bias):
+def compute_nz(alpha, beta, z0, z, nbin, sigma_z, ngal, bias, input_z_edges=None,force_equal=False):
+    """
+    alpha, beta, z0 - smail distribution variables
+    z - array of redshift values
+    nbin - number of bins to divide 
+    sigma_z - photmetric redshift uncertainty at z=0
+    ngal - total number density of galaxies in sample
+    bias - shift in n(z) distribution + or - in redshift
+    input_z_edges - optional; list of z values where to divide redshift bins
+         Either expect nbin+1 values (for bin edges) or 2 values, which will 
+         specify zmin and zmax for bin divisions (this zmin and max
+         are distinct from the input options which control range of z
+         values tabulated in array
+    force_equal - if True, independentently of bin division, specifies 
+           that all z bins will have equal number densities
+    """
     # Set up Smail distribution of z vector as the distribution of true redshifts of the galaxies, n(ztrue)
     nz_true = smail_distribution(z, alpha, beta, z0)
 
     # Multiply that by a Gaussian to get the probability distribution of the measured photo-z for each true redshift p(zphot|ztrue)
     # This gives a 2D probability distribution
     z_prob_matrix = photometric_error(z, nz_true, sigma_z, bias)
-    edges = find_bins(z, nz_true, nbin)
-    bin_nz = compute_bin_nz(z_prob_matrix, z, edges, ngal)
-    return edges, bin_nz
+
+    if input_z_edges is None:
+        edges = find_bins(z, nz_true, nbin)
+    elif (input_z_edges.size==2):
+        # equal numbers in bins, with nominal min and max set by input_z_edges
+        edges = find_bins(z, nz_true, nbin, input_z_edges[0], input_z_edges[1])
+    else:
+        edges = input_z_edges
+
+    
+    bin_nz = compute_bin_nz(z_prob_matrix, z, edges,ngal)
+    if force_equal:
+        ngals = ngal/nbin*np.ones(nbin)
+    else:
+        ngals = get_ngals_presmooth(nz_true,z,edges,ngal)
+    return edges, bin_nz, ngals
 
 
 def setup(options):
+    # Determine how z values are tabulated
     dz = options.get_double(option_section, "dz", default=0.01)
     zmax = options.get_double(option_section, "zmax", default=4.0)
+    zmin = options.get_double(option_section, "zmin", default=0.)
+    # how many redshift bins are we dividing distribution into?
     nbin = options.get_int(option_section, "nbin")
+    # specify that number densities for bins are equal
+    force_equal = options.get_bool(option_section,"enforce_equal_numbers",default=False)
+    # where to find input parameters and how to store in datablock
     in_section = options.get_string(option_section, "input_section", default=section_names.number_density_params)
     out_section = options.get_string(option_section, "output_section", default=section_names.wl_number_density)
-    return (dz, zmax, nbin, in_section, out_section)
 
+    # can optionally pass in bin divisions manually
+    if options.has_value(option_section, 'z_edges'):
+        val = options[option_section,'z_edges']
+        input_z_edges= np.atleast_1d(np.array(val, dtype=float))
+        if ((input_z_edges.size!=2) and (input_z_edges.size -1) !=nbin):
+            raise ValueError("Incompatible nbin and zedges in smail module: nbin={} and z_edges.size={}".format(nbin,input_z_edges.size))
+    else:
+        input_z_edges = None
+            
+                            
+    return (dz, zmin, zmax, nbin, in_section, out_section, input_z_edges,force_equal)
 
 def execute(block, config):
-    (dz, zmax, nbin, params, nz_section) = config
+    (dz, zmin, zmax, nbin, params, nz_section, input_z_edges, force_equal) = config
     alpha = block[params, "alpha"]
     beta = block[params, "beta"]
     z0 = block[params, "z0"]
@@ -115,10 +209,10 @@ def execute(block, config):
     bias = block.get(params, "bias")
 
     # Compute the redshift vector
-    z = np.arange(0, zmax + dz / 2, dz)
+    z = np.arange(zmin, zmax + dz / 2, dz)
 
     # Run the main code for getting n(z) in bins
-    edges, bins = compute_nz(alpha, beta, z0, z, nbin, sigma_z, ngal, bias)
+    edges, bins, ngals = compute_nz(alpha, beta, z0, z, nbin, sigma_z, ngal, bias, input_z_edges,force_equal)
 
     # Save the results
     block[nz_section, "nbin"] = nbin
@@ -134,6 +228,8 @@ def execute(block, config):
         block[nz_section, "EDGE_%d" % b] = edges[i]
         # And save the bin n(z) as a column
         block[nz_section, name] = bin
+        # also save Ngal for each bin
+        block[nz_section,"NGAL_%d" %b] = ngals[i]
     # Also save the upper limit to the top bin
     block[nz_section, "EDGE_%d" % (nbin + 1)] = edges[-1]
 

--- a/number_density/smail/photometric_smail.py
+++ b/number_density/smail/photometric_smail.py
@@ -178,10 +178,13 @@ def setup(options):
     dz = options.get_double(option_section, "dz", default=0.01)
     zmax = options.get_double(option_section, "zmax", default=4.0)
     zmin = options.get_double(option_section, "zmin", default=0.)
+
     # how many redshift bins are we dividing distribution into?
     nbin = options.get_int(option_section, "nbin")
+
     # specify that number densities for bins are equal
     force_equal = options.get_bool(option_section,"enforce_equal_numbers",default=False)
+
     # where to find input parameters and how to store in datablock
     in_section = options.get_string(option_section, "input_section", default=section_names.number_density_params)
     out_section = options.get_string(option_section, "output_section", default=section_names.wl_number_density)
@@ -190,11 +193,10 @@ def setup(options):
     if options.has_value(option_section, 'z_edges'):
         val = options[option_section,'z_edges']
         input_z_edges= np.atleast_1d(np.array(val, dtype=float))
-        if ((input_z_edges.size!=2) and (input_z_edges.size -1) !=nbin):
+        if (input_z_edges.size != 2) and (input_z_edges.size - 1 != nbin):
             raise ValueError("Incompatible nbin and zedges in smail module: nbin={} and z_edges.size={}".format(nbin,input_z_edges.size))
     else:
         input_z_edges = None
-            
                             
     return (dz, zmin, zmax, nbin, in_section, out_section, input_z_edges,force_equal)
 

--- a/number_density/smail/photometric_smail.py
+++ b/number_density/smail/photometric_smail.py
@@ -67,13 +67,12 @@ def find_bins(z, nz_true, nbin, zmin=None, zmax=None):
     """
     if zmax is None:
         zmax = z.max()
+
     if zmin is not None:
-        zmin = z.min()
-    w =(z>zmin)*(z<zmax) # only sum counts in specified range
+        w =(z>zmin)*(z<zmax) # only sum counts in specified range
     else:
         zmin=0.
         w=1.
-
 
 
     nz_true = nz_true*w


### PR DESCRIPTION
Edits adding a few additional options to smail n(z) module:
- passing in manually set divisions for photometric z bins
- passing in min and max z between which auto bin division can be gone
- saving number density per bin to the datablock