### PR TITLE
Changes to project_2d.py to allow for different source bins

### DIFF
--- a/structure/projection/project_2d.py
+++ b/structure/projection/project_2d.py
@@ -1418,10 +1418,10 @@ class SpectrumCalculator(object):
                     if power_suffix.startswith("_{") and power_suffix.endswith("}"):
                         suffix_range = power_suffix[2:-1].split("-")
                         suffices = [f"_{x}" for x in range(int(suffix_range[0]), int(suffix_range[1])+1)]
-                        only_bins_list = [[i] for i in range(int(suffix_range[0]), int(suffix_range[1])+1)]
+                        self.only_bins_list = [[i] for i in range(int(suffix_range[0]), int(suffix_range[1])+1)]
                     else:
                         suffices = [power_suffix]
-                        only_bins_list = [None]
+                        self.only_bins_list = [None]
 
                     sample_name_a = sample_name_a.strip()
                     sample_name_b = sample_name_b.strip()
@@ -1430,7 +1430,7 @@ class SpectrumCalculator(object):
                     self.req_kernel_keys.add(kernel_key_a)
                     self.req_kernel_keys.add(kernel_key_b)
 
-                    for power_suffix, only_bins in zip(suffices, only_bins_list):
+                    for power_suffix, only_bins in zip(suffices, self.only_bins_list):
 
                         # power_key is the power_3d class and suffix
                         power_key = (spectrum.power_3d_type, power_suffix)
@@ -1633,7 +1633,7 @@ class SpectrumCalculator(object):
                   f" ({spectrum.sample_a}, {spectrum.sample_b}) from P(k) {spectrum.input_section_name}")
 
         for i in range(na):
-            if not spectrum.should_do_bin(i+1):
+            if not spectrum.should_do_bin(i+1) and len(self.only_bins_list) == na:
                 continue
             # for auto-correlations C_ij = C_ji so we calculate only one of them,
             # but save both orderings to the block to account for different ordering
@@ -1644,7 +1644,7 @@ class SpectrumCalculator(object):
                 if spectrum.section_name in self.auto_only_section_names:
                     if j!=i:
                         continue
-                if not spectrum.should_do_bin(j+1):
+                if not spectrum.should_do_bin(j+1) and spectrum.kernel_types[0] == spectrum.kernel_types[1]:
                     continue
 
                 if self.verbose:


### PR DESCRIPTION
... but not complete cross-correlations. 

Motivation: if a passed power spectra is a cross-correlation between a tracer and a matter (for instance galaxy-galaxy lensing) then if the spectrum is passed for each lens bin separately, in most cases the underlying matter part will stay the same, thus can be correlated with a different tomographic bin for the source distribution. 

This change hopefully accounts for that, but will still not allow the cross-correlations if the power spectrum is the auto-correlation in the first place. This should still also be ok for the IA and magnification cases.

Apart from this, the changes to allow for general clustering work perfectly. I can produce Cells for any power spectrum generated in this case using a HOD based halo model.