### PR TITLE
Better sampling of sigma_8

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -304,11 +304,11 @@ def extract_camb_params(block, config, more_config):
     want_perturbations = more_config['mode'] not in [MODE_BG, MODE_THERM]
     want_thermal = more_config['mode'] != MODE_BG
 
-    if block.has_value('sigma_8_input'):
+    if block.has_value(cosmo, 'sigma_8_input'):
         warnings.warn("Parameter sigma8_input will be deprecated in favour of sigma_8.")
-        block['sigma_8'] = block['sigma_8_input']
+        block[cosmo, 'sigma_8'] = block[cosmo, 'sigma_8_input']
 
-    if block.has_value('A_s') and block.has_value('sigma_8'):
+    if block.has_value(cosmo, 'A_s') and block.has_value(cosmo, 'sigma_8'):
         warnings.warn("Parameter A_s is being ignored in favour of sigma_8")
 
     # Set A_s for now, this gets rescaled later if sigma_8 is provided.

--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -304,6 +304,13 @@ def extract_camb_params(block, config, more_config):
     want_perturbations = more_config['mode'] not in [MODE_BG, MODE_THERM]
     want_thermal = more_config['mode'] != MODE_BG
 
+    if block.has_value('sigma_8_input'):
+        warnings.warn("Parameter sigma8_input will be deprecated in favour of sigma_8.")
+        block['sigma_8'] = block['sigma_8_input']
+
+    if block.has_value('A_s') and block.has_value('sigma_8'):
+        warnings.warn("Parameter A_s is being ignored in favour of sigma_8")
+
     # Set A_s for now, this gets rescaled later if sigma_8 is provided.
     if not block.has_value(cosmo, 'A_s'):
         block[cosmo, 'A_s'] = DEFAULT_A_S
@@ -601,10 +608,7 @@ def recompute_for_sigma8(camb_results, block, config, more_config):
     # This reuses the transfer function, which is what takes time to compute
     sigma8 = camb_results.get_sigma8_0()
 
-    if block.has_value(cosmo, 'sigma_8'):
-        sigma_8_target = block[cosmo,'sigma_8']
-    else:
-        sigma_8_target = block[cosmo,'sigma_8_input']
+    sigma_8_target = block[cosmo,'sigma_8']
     block[cosmo,'A_s'] = block[cosmo,'A_s'] * sigma_8_target**2/sigma8**2
     init_power_scaled = extract_initial_power_params(block, config, more_config)
 
@@ -625,8 +629,7 @@ def execute(block, config):
         else:
             # other modes
             r = camb.get_results(p)
-            if (block.has_value(cosmo, 'sigma_8_input') 
-                    or block.has_value(cosmo, 'sigma_8')):
+            if block.has_value(cosmo, 'sigma_8'):
                 r = recompute_for_sigma8(r, block, config, more_config)
 
     except camb.CAMBError:

--- a/boltzmann/camb/module.yaml
+++ b/boltzmann/camb/module.yaml
@@ -264,6 +264,11 @@ inputs:
             meaning: Primordial scalar spectral amplitude
             type: real
             default:
+        sigma_8:
+            meaning: Amplitude of linear perturbations at z=0 on scales of 8 Mpc/h.
+                Only A_s or sigma_8 should be provided.
+            type: real
+            default:
         hubble:
             meaning: Hubble parameter in km/s/Mpc
             type: real

--- a/examples/des-y1-values.ini
+++ b/examples/des-y1-values.ini
@@ -7,7 +7,7 @@ n_s          =  0.87      0.9676        1.07
 ; the likelihood will be the same, but the prior will
 ; be different.
 ; A_s          =  0.5e-09  2.260574e-09  5.0e-09
-sigma_8_input = 0.5  0.8341371714072584   1.0
+sigma_8      = 0.5  0.8341371714072584   1.0
 w            = -1.0
 omega_k      =  0.0
 tau          =  0.08


### PR DESCRIPTION
This PR replaces the janky sigma_8 sampling setup. Instead of running CAMB twice, the transfer function (which takes the most time) is only computed once and then the power spectra are recomputed using the correct A_s corresponding to the requested sigma_8.

This speeds things up by ~50% and also avoids the numerical uncertainty in the initial estimate of sigma_8 due to the low accuracy settings of the first run. Since `sigma_8_input` now agrees with the output `sigma_8`, I added the option of taking `sigma_8` as the input directly. If both `sigma_8` and `A_s` are provided, `sigma_8` takes precedence.

This approach could in principle be used to do fast sampling of all non-cosmology parameters, such as primordial power spectrum parameters in general or HMCode parameters. See for example cells 50 onward here: https://camb.readthedocs.io/en/latest/CAMBdemo.html