### PR TITLE
Transfer function to data block

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -565,6 +565,16 @@ def save_matter_power(r, block, more_config):
         # Save the linear
         section_name = matter_power_section_names[transfer_type] + "_lin"
         block.put_grid(section_name, "z", z, "k_h", k, "p_k", p_k)
+        
+        # Save the transfer function
+        # Note that the transfer function has different k range and precision as
+        # there is no interpolating function for it in CAMB.
+        # We might consider creating an interpolator ...
+        section_name_transfer = matter_power_section_names[transfer_type] + "_transfer_func"
+        transfer_func = r.get_matter_transfer_data().transfer_z(tt)
+        k_transfer_func = r.get_matter_transfer_data().transfer_z("k/h")
+        block.put_double_array_1d(section_name_transfer, "k_h", k_transfer_func)
+        block.put_double_array_1d(section_name_transfer, "t_k", transfer_func)
 
         # Now if requested we also save the linear version
         if p.NonLinear is not camb.model.NonLinear_none:


### PR DESCRIPTION
Touches the issue #116 I have opened.

Exposed transfer function to the data block. Probably needs a couple of iterations to include extra functionality. For instance I can think of having the return governed in the config, as well as better redshift handling (currently only replicating the input required for `hmf`, and that is not general enough) and interpolation...

