### PR TITLE
Update classy.pyx for cython v3.0.0+

### DIFF
--- a/boltzmann/class/class_v3.2.0/python/classy.pyx
+++ b/boltzmann/class/class_v3.2.0/python/classy.pyx
@@ -100,10 +100,10 @@ cdef class Class:
     cdef distortions sd
     cdef file_content fc
 
-    cpdef int computed # Flag to see if classy has already computed with the given pars
-    cpdef int allocated # Flag to see if classy structs are allocated already
-    cpdef object _pars # Dictionary of the parameters
-    cpdef object ncp   # Keeps track of the structures initialized, in view of cleaning.
+    cdef int computed # Flag to see if classy has already computed with the given pars
+    cdef int allocated # Flag to see if classy structs are allocated already
+    cdef object _pars # Dictionary of the parameters
+    cdef object ncp   # Keeps track of the structures initialized, in view of cleaning.
 
     # Defining two new properties to recover, respectively, the parameters used
     # or the age (set after computation). Follow this syntax if you want to
@@ -128,7 +128,7 @@ cdef class Class:
         self.set(**_pars)
 
     def __cinit__(self, default=False):
-        cpdef char* dumc
+        cdef char* dumc
         self.allocated = False
         self.computed = False
         self._pars = {}

--- a/module.yaml
+++ b/module.yaml
@@ -39,3 +39,4 @@ outputs:
             meaning:
             type:
             default:
+


### PR DESCRIPTION
Cython version 3.0.0+ deprecated the use of cpdef for variables. This means that cosmosis-build-standard-library crashes with the newest versions of cython. This patch fixes the crash. It should also be backward compatible to earlier versions of cython, I think... 