### PR TITLE
Update module.yaml for the added transfer function output in the camb interface

### DIFF
--- a/boltzmann/camb/module.yaml
+++ b/boltzmann/camb/module.yaml
@@ -602,3 +602,11 @@ outputs:
         p_k:
             meaning: Non-linear power spectrum at samples in (Mpc/h)^-3.
             type: real 2d
+    transfer_func:
+        k_h:
+            meaning: Wavenumbers k of samples in Mpc/h.
+                Different than the k of power spectra!
+            type: real 1d
+        t_k:
+            meaning: Linear transfer function at z=0.
+            type: real 1d


### PR DESCRIPTION
Added the missing references to the returned transfer function, long delayed.