### PR TITLE
Additions to the two_point.py enabling one to add a 1pt statistics to the cosmosis data file

### DIFF
--- a/likelihood/2pt/type_table.txt
+++ b/likelihood/2pt/type_table.txt
@@ -6,6 +6,9 @@ galaxy_shear_emode_fourier  cmb_kappa_emode_fourier      shear_cmbkappa_cl   ell
 cmb_shear_emode_fourier     galaxy_shear_emode_fourier   shear_cmbkappa_cl   ell   bin_{1}_{0}
 galaxy_position_fourier     cmb_kappa_emode_fourier      galaxy_cmbkappa_cl  ell   bin_{0}_{1}
 cmb_shear_emode_fourier     galaxy_position_fourier      galaxy_cmbkappa_cl  ell   bin_{1}_{0}
+galaxy_position_fourier     galaxy_position_fourier      bandpower_clustering           ell   bin_{0}_{1}
+galaxy_shear_emode_fourier  galaxy_shear_emode_fourier   bandpower_shear_e            ell   bin_{0}_{1}
+galaxy_position_fourier     galaxy_shear_emode_fourier   bandpower_ggl     ell   bin_{0}_{1}
 galaxy_shear_plus_real      galaxy_shear_plus_real       shear_xi_plus       theta bin_{0}_{1}
 galaxy_shear_plus_real      galaxy_shear_plus_real       shear_xi_plus       theta bin_{0}_{1}
 galaxy_shear_minus_real     galaxy_shear_minus_real      shear_xi_minus      theta bin_{0}_{1}


### PR DESCRIPTION
This adds the functionality to the two_point.py which enables to include a 1pt statistics (in the like of stellar mass function, luminosity function, and similar) to the cosmosis fits files and allows those to be included in the likelihood.

It probably needs more testing and bug fixing, as I have probably not captured all edge cases when implementing the additions. 🫣

Due to the behaviour of 1pt statistics, a lot was borrowed from the NumberDensity class.

The covariance construction seems a bit hacky as well. 🤷‍♂️