### PR TITLE
Do not run baccoemu on python 3.12 or newer

### DIFF
--- a/tests/test_cosmosis_standard_library.py
+++ b/tests/test_cosmosis_standard_library.py
@@ -143,6 +143,10 @@ def test_kids(capsys):
     check_no_camb_warnings(capsys)
 
 def test_bacco():
+    if sys.version_info > (3, 11):
+        # We don't have tensorflow support in 3.12 yet, so
+        # we can't run baccoemu.
+        return
     # The baseline version just does non-linear matter power
     run_cosmosis("examples/bacco.ini")
 


### PR DESCRIPTION
Because there is no tensorflow build on Python 3.12 yet, we can't run baccoemu on Python 3.12. This should stop the tests from failing by not *trying* to run baccoemu under python 3.12 or newer.

This needs to be undone wherever tensorflow finally support Python 3.12.