### PR TITLE
Implement interface with Candl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install likelihood python dependencies from pip
         shell: bash -l {0}
         run: |
-          pip install "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing"
+          pip install "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing" candl-like
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,11 @@ jobs:
         run: |
           pip install "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing"
 
-      - name: Install recent python dependencies
-        if:  ${{ (matrix.pyversion != '3.7') && (matrix.pyversion != '3.8') }}
-        run: |
-            pip install "candl-like"
+      # Not working - don't know why
+      # - name: Install recent python dependencies
+      #   if:  ${{ (matrix.pyversion != '3.7') && (matrix.pyversion != '3.8') }}
+      #   run: |
+      #       pip install "candl-like"
     
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,11 +232,7 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools
         pip install "cosmosis==3.9.2" "nautilus-sampler==1.0.1" "scipy<1.14"
         pip install -v --no-cache-dir --no-binary=mpi4py,camb mpi4py camb
-        pip install fitsio astropy fast-pt "Cython>=3.0" jupyter sacc "git+https://github.com/carronj/planck_PR4_lensing"
-
-    - name: Install likelihood python dependencies
-      run: |
-        pip install "act_dr6_lenslike>=1.0.2"
+        pip install fitsio astropy fast-pt "Cython>=3.0" jupyter sacc "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing" candl-like
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,13 @@ jobs:
       - name: Install likelihood python dependencies from pip
         shell: bash -l {0}
         run: |
-          pip install "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing" candl-like
+          pip install "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing"
 
+      - name: Install recent python dependencies
+        if:  ${{ (matrix.pyversion != '3.7') && (matrix.pyversion != '3.8') }}
+        run: |
+            pip install "candl-like"
+    
       - name: Run Tests
         shell: bash -l {0}
         run: |
@@ -232,7 +237,13 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools
         pip install "cosmosis==3.9.2" "nautilus-sampler==1.0.1" "scipy<1.14"
         pip install -v --no-cache-dir --no-binary=mpi4py,camb mpi4py camb
-        pip install fitsio astropy fast-pt "Cython>=3.0" jupyter sacc "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing" candl-like
+        pip install fitsio astropy fast-pt "Cython>=3.0" jupyter sacc "act_dr6_lenslike>=1.0.2" "git+https://github.com/carronj/planck_PR4_lensing"
+    
+    - name: Install recent python dependencies
+      if:  ${{ (matrix.python-version != '3.7') && (matrix.python-version != '3.8') }}
+      run: |
+        pip install "candl-like"
+        
 
     - name: Build
       run: |

--- a/examples/candl_test.ini
+++ b/examples/candl_test.ini
@@ -5,7 +5,7 @@ resume       = T
 verbosity    = noisy
 
 [test]
-save_dir     = output/spt3g_20192020_lensing
+save_dir     = output/spt3g_2018_lensing
 fatal_errors = T
 
 [nautilus]

--- a/examples/candl_test.ini
+++ b/examples/candl_test.ini
@@ -1,0 +1,64 @@
+[runtime]
+sampler      = test
+root         = ${PWD}
+resume       = T
+verbosity    = noisy
+
+[test]
+save_dir     = output/spt3g_20192020_lensing
+fatal_errors = T
+
+[nautilus]
+n_live       = 1500
+verbose      = T
+
+[emcee]
+walkers      = 64
+samples      = 1000
+nsteps       = 5
+
+
+[pipeline]
+; these names refer to sections later in the file:
+modules = consistency camb spt3g_2018_lensing
+values  = examples/candl_test_values.ini
+priors  = examples/candl_test_priors.ini
+debug   = F
+timing  = F
+extra_output = cosmological_parameters/sigma_8 cosmological_parameters/omega_m
+
+[spt3g_2018_lensing]
+file = ./likelihood/candl/candl_cosmosis_interface.py ; Location of interface code - change depending on the location of your .ini file
+data_set = 'candl.data.SPT3G_2018_Lens' ; Data set or path to .yaml file
+variant = 'use_CMB' ; Select a variant of the data set if pointing to an index file
+lensing = T ; Switch on for lensing likelihoods
+feedback = T ; Switch on to request feedback from candl initialisation
+data_selection = "..." ; Select a subset of the data set
+clear_1d_internal_priors = F ; Switch off to use candl internal 1d priors
+clear_nd_internal_priors = F ; Switch on to ignore candl internal higher dimensional priors. Careful: higher-dimensional priors are not implemented in CosmoSIS itself.
+force_ignore_transformations = '' ; Backdoor if you want to ignore certain transformations in the data model.
+
+[output]
+filename = output/spt3g-18-lens.txt
+
+; The consistency module translates between our chosen parameterization
+; and any other that modules in the pipeline may want (e.g. camb)
+[consistency]
+file = ./utility/consistency/consistency_interface.py
+cosmomc_theta = T
+
+[camb]
+file = boltzmann/camb/camb_interface.py
+feedback = 0                   ; verbosity of output
+mode     = cmb                 ; mode to run camb. For CMB lensing only, cmb is sufficient 
+lmax     = 4000                ; max ell to use for cmb calculation
+lens_margin     = 1250         ; Lmax
+AccuracyBoost   = 1.0          ; CAMB accuracy boost parameter
+lSampleBoost    = 1.0          ; CAMB lsample boost parameter
+lAccuracyBoost  = 1.0          ; CAMB lAccuracy boost parameter
+lens_potential_accuracy = 4    ; CAMB lens_potential accuracy paramater
+do_tensors      = T            ;include tensor modes
+do_lensing      = T            ;lensing is required w/ Planck data
+NonLinear       = lens         ; Non-linear calculation
+theta_H0_range  = "20 100"     ; Set bounds in H0
+halofit_version = takahashi    ; Halofit version 

--- a/examples/candl_test_priors.ini
+++ b/examples/candl_test_priors.ini
@@ -1,0 +1,3 @@
+[cosmological_parameters]
+ombh2 = normal 0.02233 0.00036
+n_s = normal 0.96 0.02

--- a/examples/candl_test_values.ini
+++ b/examples/candl_test_values.ini
@@ -1,0 +1,16 @@
+
+[cosmological_parameters]
+omch2         = 0.08 0.12 0.16
+ombh2         = 0.01 0.02233 0.03
+log1e10As     = 2.9 3.0448  3.2
+n_s           = 0.86 0.96 1.06
+cosmomc_theta = 0.9  1.04  1.20
+omega_k       = 0.0
+mnu           = 0.06
+nnu           = 3.046
+yhe           = 0.245341
+tau           = 0.0543 
+num_massive_neutrinos = 3
+
+[nuisance_parameters]
+A_fg       = 0.0 1.0 2.0

--- a/likelihood/candl/README.txt
+++ b/likelihood/candl/README.txt
@@ -1,0 +1,33 @@
+candl - CosmoSIS interface
+---------------------------
+
+The files in this folder help you load any candl (https://github.com/Lbalkenhol/candl) likelihood into CosmoSIS.
+
+Usage
+---------------------------
+
+In order run chains with e.g. the SPT-3G 2018 lensing likelihood, include the following block in your ``.ini`` file:
+
+file = ./likelihood/candl/candl_cosmosis_interface.py ; Location of interface code - change depending on the location of your .ini file
+data_set = 'candl.data.SPT3G_2018_Lens' ; Data set or path to .yaml file
+variant = 'use_CMB' ; Select a variant of the data set if pointing to an index file
+lensing = T ; Switch on for lensing likelihoods
+feedback = T ; Switch on to request feedback from candl initialisation
+data_selection = "..." ; Select a subset of the data set
+clear_1d_internal_priors = T ; Switch off to use candl internal 1d priors
+clear_nd_internal_priors = F ; Switch on to ignore candl internal higher dimensional priors. Careful: higher-dimensional priors are not implemented in CosmoSIS itself.
+force_ignore_transformations = '' ; Backdoor if you want to ignore certain transformations in the data model.
+
+Mofidy the information above as needed for other data sets. You can also consult the candl documentation for more information (https://candl.readthedocs.io/en/latest/).
+
+Note that by default the 1-dimensional internal priors declared in candl's data set ``.yaml`` file are ignored, while the multi-dimensional priors are applied. If you want to modify this behaviour, set ``clear_1d_internal_priors`` and ``clear_nd_internal_priors``.
+
+Credit
+---------------------------
+
+If you use this wrapper in your work please cite candl (https://arxiv.org/abs/2401.13433) as well as the relevant paper for all likelihoods you have accessed.
+
+Authors
+---------------------------
+
+This wrapper was written by Y. Omori and L. Balkenhol, with help from J. Zuntz. If you have any questions or experience issues, please feel free to contact L. Balkenhol (lennart.balkenhol_at_iap.fr).

--- a/likelihood/candl/README.txt
+++ b/likelihood/candl/README.txt
@@ -30,4 +30,4 @@ If you use this wrapper in your work please cite candl (https://arxiv.org/abs/24
 Authors
 ---------------------------
 
-This wrapper was written by Y. Omori and L. Balkenhol, with help from J. Zuntz. If you have any questions or experience issues, please feel free to contact L. Balkenhol (lennart.balkenhol_at_iap.fr).
+This wrapper was written by  L. Balkenhol and Y. Omori, with help from J. Zuntz. If you have any questions or experience issues, please feel free to contact L. Balkenhol (lennart.balkenhol_at_iap.fr).

--- a/likelihood/candl/candl_cosmosis_interface.py
+++ b/likelihood/candl/candl_cosmosis_interface.py
@@ -1,0 +1,175 @@
+try:
+    from candl.lib import *
+    import candl
+    import candl.data
+except ImportError:
+    raise RuntimeError('Can not find candl. Try running: pip install candl-like')
+
+from cosmosis.datablock import names, SectionOptions
+import numpy as np
+import os
+
+class CandlCosmoSISLikelihood:
+    """
+    A thin wrapper to use candl likelihoods in CosmoSIS.
+    """
+
+    def __init__(self, options):
+        """
+        Read in options from CosmoSIS ini file and initialise requested candl likelihood.
+        """
+
+        # Read requested data set from ini and grab a name under which the logl value will be recorded
+        data_set_str = options.get_string("data_set", default="")
+        if data_set_str[:11] == "candl.data.":
+            # This looks like a short-cut to a pre-installed data set, e.g. "candl.data.SPT3G_2018_Lens"
+            self.data_set_file = eval(data_set_str)
+            self.name = "candl." + data_set_str.split(".")[-1]
+        else:
+            # Assume this to be a path pointing directly to a data set .yaml file
+            self.data_set_file = data_set_str
+            self.name = "candl." + self.data_set_file.split("/")[-1][:-5]
+
+        # Read in other options from ini
+        self.lensing = options.get_bool('lensing', default=True)
+        self.clear_1d_internal_priors = options.get_bool('clear_1d_internal_priors', default=True)
+        self.clear_nd_internal_priors = options.get_bool('clear_nd_internal_priors', default=False)# CosmoSIS only has 1d priors implemented
+        self.feedback = options.get_bool('feedback', default=True)
+
+        # Optional entries
+        init_args = {"feedback": self.feedback}
+        
+        # Data selection
+        if options.has_value("data_selection"):
+            self.data_selection = options.get_string("data_selection", default="...")
+            data_selection_requested = True
+            if isinstance(self.data_selection, str):
+                if self.data_selection == "...":
+                    data_selection_requested = False
+            if data_selection_requested:
+                init_args["data_selection"] = self.data_selection
+
+        # Likelihood variant
+        if options.has_value("variant"):
+            self.variant_str = options.get_string("variant", default=None)
+            init_args["variant"] = self.variant_str
+
+        # Force ignore transformations
+        if options.has_value("force_ignore_transformations"):
+            self.force_ignore_transformations = options.get_string("force_ignore_transformations", default=None)
+            init_args["force_ignore_transformations"] = self.force_ignore_transformations
+
+        # Initialise the likelihood
+        try:
+            if self.lensing:
+                self.candl_like = candl.LensLike(
+                    self.data_set_file,
+                    **init_args,
+                )
+            else:
+                self.candl_like = candl.Like(
+                    self.data_set_file,
+                    **init_args,
+                )
+        except:
+            raise Exception("candl: likelihood could not be initialised!")
+
+        # By default clear internal priors and assume these are taken care off by CosmoSIS
+        keep_prior_ix = []
+        for i, prior in enumerate(self.candl_like.priors):
+            if prior.prior_covariance.shape[0] == 1 and not self.clear_1d_internal_priors:
+                keep_prior_ix.append(i)
+            elif prior.prior_covariance.shape[0] > 1 and not self.clear_nd_internal_priors:
+                keep_prior_ix.append(i)
+        self.candl_like.priors = [self.candl_like.priors[i] for i in keep_prior_ix]
+
+
+    def reformat(self,block):
+        """
+        Converting from CosmoSIS to candl format
+        """
+
+        model_dict = {}
+        
+        # Load all cosmological parameters and add extra params so that candl understands
+        # These should not be needed by candl, but it doesn't hurt in case anyone builds a likelihood that directly depends on cosmological parameters
+        cos_par_names      = [param_name for param_sec, param_name in block.keys() if param_sec == 'cosmological_parameters']
+        model_dict = {par: block[('cosmological_parameters',par)] for par in cos_par_names}
+        model_dict['H0']   = model_dict['h0']*100
+        model_dict['ns']   = model_dict['n_s']
+        model_dict['logA'] = model_dict['log1e10as']
+        
+        # Load all nuisance parameters
+        nuisance_par_names      = [param_name for param_sec, param_name in block.keys() if param_sec == 'nuisance_parameters']
+
+        # Match any nuisance parameters in candl and restore right cases
+        like_nuisance_pars_lowered = [p.lower() for p in self.candl_like.required_nuisance_parameters]
+        for i, par in enumerate(nuisance_par_names):
+            if par in like_nuisance_pars_lowered:
+                nuisance_par_names[i] = self.candl_like.required_nuisance_parameters[like_nuisance_pars_lowered.index(par)]
+
+        for par in nuisance_par_names:
+            model_dict[par] = block[('nuisance_parameters',par)]# CosmoSIS doesn't care about cases, so putting them in is easy
+        
+        # Read in Cls from CosmoSIS and save them in dict.
+        # CosmoSIS outputs CAMB Cls in unit of l(l+1)/(2pi)
+        # For pp it's ell * (ell + 1) / (2 * np.pi) - i.e. missing the customary extra ell * (ell + 1) wrt eg the CAMB standard
+        # This matches candl expectations for primary CMB - but we need to convert this for lensing
+        ell = block[names.cmb_cl, 'ell']
+        cl_tt = block[names.cmb_cl, 'tt']
+        cl_ee = block[names.cmb_cl, 'ee']
+        cl_te = block[names.cmb_cl, 'te']
+        cl_bb = block[names.cmb_cl, 'bb']
+        cl_pp = block[names.cmb_cl, 'pp'] * ell * (ell + 1)
+        cl_kk = cl_pp * np.pi / 2.0
+
+        # Figure out ell range of supplied spectra w.r.t. the expectation of the likelihood
+        N_ell = self.candl_like.ell_max - self.candl_like.ell_min + 1
+
+        theory_start_ix = (
+            np.amax((ell[0], self.candl_like.ell_min))
+            - ell[0]
+        )
+        theory_stop_ix = (
+            np.amin((ell[-1], self.candl_like.ell_max))
+            + 1
+            - ell[0]
+        )
+
+        like_start_ix = (
+            np.amax((ell[0], self.candl_like.ell_min)) - self.candl_like.ell_min
+        )
+        like_stop_ix = (
+            np.amin((ell[-1], self.candl_like.ell_max))
+            + 1
+            - self.candl_like.ell_min
+        )
+
+        # Slot supplied CMB spectra into an array of zeros of the correct length
+        # candl will optionally import JAX which should ensure the two methods below run
+        model_dict['Dl'] = {'ell': np.arange(self.candl_like.ell_min, self.candl_like.ell_max + 1)}
+        for spec_type, spec in zip(["pp", "kk", "TT", "EE", "BB", "TE"], [cl_pp, cl_kk, cl_tt, cl_ee, cl_bb, cl_te]):
+            model_dict['Dl'][spec_type] = jnp.zeros(N_ell)
+            model_dict['Dl'][spec_type] = jax_optional_set_element(
+                model_dict['Dl'][spec_type],
+                np.arange(like_start_ix, like_stop_ix),
+                spec[theory_start_ix:theory_stop_ix],
+            )
+
+        return model_dict
+    
+
+    def likelihood(self, block):
+        '''Computes loglike'''
+        logl  = self.candl_like.log_like(self.reformat(block))
+        return float(logl)
+
+
+def setup(options):
+    options = SectionOptions(options)
+    return CandlCosmoSISLikelihood(options)
+
+def execute(block, config):
+    like    = config.likelihood(block)
+    block[names.likelihoods, "%s_like"%config.name] = like
+    return 0

--- a/likelihood/candl/module.yaml
+++ b/likelihood/candl/module.yaml
@@ -1,0 +1,83 @@
+name: "candl"
+version: "1.0.0"
+purpose: "Interface with candl."
+url: "https://github.com/Lbalkenhol/candl"
+interface: "candl_cosmosis_interface.py"
+attribution: ["Y. Omori", "L. Balkenhol"]
+rules:
+    "None"
+cite:
+    - "https://doi.org/10.48550/arXiv.2401.13433"
+
+assumptions:
+    - "candl python module"
+
+explanation: |
+    "Interface to candl."
+
+# List of parameters that can go in the params.ini file in the section for this module    
+params:
+    data_set:
+        meaning: "The data set to use"
+        type: str
+    variant:
+        meaning: "Variant of the data set requested, if applicable."
+        type: str
+        default: None
+    lensing:
+        meaning: "Lensing likelihood (or primary CMB)."
+        type: bool
+        default: True
+    feedback:
+        meaning: "Whether to generate feedback from the likelihood initialisation."
+        type: bool
+        default: True
+    data_selection:
+        meaning: "Further data selection"
+        type: any
+        default: "..."
+    clear_1d_internal_priors:
+        meaning: "Delete all 1d Gaussian priors implemented in candl."
+        type: bool
+        default: True
+    clear_nd_internal_priors:
+        meaning: "Delete all >1d Gaussian priors implemented in candl. Beware: CosmoSIS does not have support for higher-dimensional Gaussian priors."
+        type: bool
+        default: False
+    force_ignore_transformations:
+        meaning: "Backdoor to explicitly ignore certain transformations in the data model. See candl documentation for more information."
+        type: str
+        default: None
+
+inputs:
+    cmb_cl:
+        ell:
+            meaning: "CMB power spectrum ell values of other inputs"
+            type: real 1d
+            default:
+        tt:
+            meaning: "Lensed CMB temperature power spectrum in ell(ell+1)/2pi units"
+            type: real 1d
+            default:
+        te:
+            meaning: "Lensed CMB temperature-E-mode polarization cross power spectrum in ell(ell+1)/2pi units"
+            type: real 1d
+            default:
+        ee:
+            meaning: "Lensed CMB E-mode polaration power spectrum in ell(ell+1)/2pi units"
+            type: real 1d
+            default:
+        bb:
+            meaning: "Lensed CMB B-mode polaration power spectrum in ell(ell+1)/2pi units"
+            type: real 1d
+            default:
+        pp:
+            meaning: "CMB lensing phi-phi power spectrum in ell(ell+1)/2pi units"
+            type: real 1d
+            default:
+
+outputs:
+    likelihoods:
+        candl_like:
+            meaning: "candl likelihood"
+            type: real

--- a/tests/test_cosmosis_standard_library.py
+++ b/tests/test_cosmosis_standard_library.py
@@ -199,5 +199,9 @@ def test_desi(capsys):
     check_likelihood(capsys, "-11.25")
 
 def test_candl(capsys):
+    try:
+        import candl
+    except ImportError:
+        pytest.skip("Candl not installed")
     run_cosmosis("examples/candl_test.ini")
     check_likelihood(capsys, "-5.83")

--- a/tests/test_cosmosis_standard_library.py
+++ b/tests/test_cosmosis_standard_library.py
@@ -197,3 +197,7 @@ def test_npipe(capsys):
 def test_desi(capsys):
     run_cosmosis("examples/desi.ini")
     check_likelihood(capsys, "-11.25")
+
+def test_candl(capsys):
+    run_cosmosis("examples/candl_test.ini")
+    check_likelihood(capsys, "-5.83")


### PR DESCRIPTION
This PR implements a small code that interfaces with [Candl ](https://candl.readthedocs.io/en/latest/data/data_overview.html), which allows you to interact with both published ACT/SPT likelihoods.