### PR TITLE
Get f(z) used for RSD calcs from datablock instead of a spline fit

### DIFF
--- a/structure/projection/module.yaml
+++ b/structure/projection/module.yaml
@@ -202,6 +202,10 @@ params:
         meaning: Whether to compute RSD in non-limber calculations
         type: bool
         default: False
+    fz_from_block:
+        meaning: Whether to get f(z) used in RSD from the datablock. If False, from spline derivative of P(k,z). 
+	type: bool
+	default: False
 inputs:
     matter_power_nl:
         k_h:

--- a/structure/projection/project_2d.py
+++ b/structure/projection/project_2d.py
@@ -109,7 +109,9 @@ class Power3D(object):
         """
         self.chi_logk_spline = interp.RectBivariateSpline(self.chi_vals, self.logk_vals, self.pk_vals)
 
-    def set_nonlimber_splines(self, block, chi_of_z, k_growth=1.e-3):
+            ### JMedit Nov 6, 2024
+    def set_nonlimber_splines(self, block, chi_of_z, k_growth=1.e-3, fz_from_block=False):
+                ### end of JMedit
         """
         Set up various splines etc. needed for the exact projection
         calculation
@@ -156,15 +158,23 @@ class Power3D(object):
         P_sublin_vals = self.pk_vals - P_lin_from_growth
         self.sublin_spline = interp.RectBivariateSpline(self.chi_vals, self.logk_vals, P_sublin_vals)
 
-        # When doing RSD, we also need f(a(\chi)) = dln(D(a(chi)))/dlna
-        a_vals = 1/(1+self.z_vals)
-        # Make ln(D)(ln(a)) spline
-        lnD_of_lna_spline = interp.InterpolatedUnivariateSpline(np.log(a_vals)[::-1], np.log(growth_vals)[::-1])
-        # And take derivative
-        f = (lnD_of_lna_spline.derivative())(np.log(a_vals))
-        # Now can set f(chi) spline.
-        self.f_of_chi_spline = interp.InterpolatedUnivariateSpline(self.chi_vals, f)
-
+        
+        ### JMedit Nov 6, 2024
+        if  fz_from_block:
+            z_growth = block[names.growth_parameters,'z']
+            chi_growth = chi_of_z(z_growth)
+            f_growth = block[names.growth_parameters,'f_z']
+            self.f_of_chi_spline = interp.InterpolatedUnivariateSpline(chi_growth, f_growth)
+        else:             # previous standard behavior is to do this spline derivatie
+            # When doing RSD, we also need f(a(\chi)) = dln(D(a(chi)))/dlna
+            a_vals = 1/(1+self.z_vals)
+            # Make ln(D)(ln(a)) spline
+            lnD_of_lna_spline = interp.InterpolatedUnivariateSpline(np.log(a_vals)[::-1], np.log(growth_vals)[::-1])
+            # And take derivative
+            f = (lnD_of_lna_spline.derivative())(np.log(a_vals))
+            # Now can set f(chi) spline.
+            self.f_of_chi_spline = interp.InterpolatedUnivariateSpline(self.chi_vals, f)
+        ### end of JMedit
 class MatterPower3D(Power3D):
     section = "matter_power_nl"
     lin_section = "matter_power_lin"
@@ -1221,7 +1231,11 @@ class SpectrumCalculator(object):
         self.fatal_errors = options.get_bool(option_section, "fatal_errors", False)
         self.get_kernel_peaks = options.get_bool(option_section, "get_kernel_peaks", False)
         self.save_kernels = options.get_bool(option_section, "save_kernels", False)
-
+        ### JMedit Nov 6, 2024
+        # get the growth rate f(z) from previous datablock calculations
+        # instead of by taking a spline derivative of tabulated P(k,z)
+        self.fz_from_block = options.get_bool(option_section, "fz_from_block", False)
+        ### end of JMedit
         self.limber_ell_start = options.get_int(option_section, "limber_ell_start", 300)
         do_exact_string = options.get_string(option_section, "do_exact", "")
         if do_exact_string=="":
@@ -1595,7 +1609,9 @@ class SpectrumCalculator(object):
                 print(f"Loading {power.section_name} 3D power spectrum")
             power.load_from_block(block, self.chi_of_z)
             if do_exact:
-                power.set_nonlimber_splines(block, self.chi_of_z)
+                ### JMedit Nov 6, 2024, adding fz_from_block argument
+                power.set_nonlimber_splines(block, self.chi_of_z, fz_from_block = self.fz_from_block)
+                ### end of JMedit
             power_key = (powertype, suffix)
             self.power[power_key] = power
 

--- a/structure/projection/project_2d.py
+++ b/structure/projection/project_2d.py
@@ -109,9 +109,7 @@ class Power3D(object):
         """
         self.chi_logk_spline = interp.RectBivariateSpline(self.chi_vals, self.logk_vals, self.pk_vals)
 
-            ### JMedit Nov 6, 2024
     def set_nonlimber_splines(self, block, chi_of_z, k_growth=1.e-3, fz_from_block=False):
-                ### end of JMedit
         """
         Set up various splines etc. needed for the exact projection
         calculation
@@ -157,15 +155,13 @@ class Power3D(object):
         P_lin_from_growth = np.outer(growth_vals**2, P_lin_z0_resamp)
         P_sublin_vals = self.pk_vals - P_lin_from_growth
         self.sublin_spline = interp.RectBivariateSpline(self.chi_vals, self.logk_vals, P_sublin_vals)
-
         
-        ### JMedit Nov 6, 2024
         if  fz_from_block:
             z_growth = block[names.growth_parameters,'z']
             chi_growth = chi_of_z(z_growth)
             f_growth = block[names.growth_parameters,'f_z']
             self.f_of_chi_spline = interp.InterpolatedUnivariateSpline(chi_growth, f_growth)
-        else:             # previous standard behavior is to do this spline derivatie
+        else:             # standard behavior is to do this spline derivative
             # When doing RSD, we also need f(a(\chi)) = dln(D(a(chi)))/dlna
             a_vals = 1/(1+self.z_vals)
             # Make ln(D)(ln(a)) spline
@@ -174,7 +170,7 @@ class Power3D(object):
             f = (lnD_of_lna_spline.derivative())(np.log(a_vals))
             # Now can set f(chi) spline.
             self.f_of_chi_spline = interp.InterpolatedUnivariateSpline(self.chi_vals, f)
-        ### end of JMedit
+
 class MatterPower3D(Power3D):
     section = "matter_power_nl"
     lin_section = "matter_power_lin"
@@ -1231,11 +1227,11 @@ class SpectrumCalculator(object):
         self.fatal_errors = options.get_bool(option_section, "fatal_errors", False)
         self.get_kernel_peaks = options.get_bool(option_section, "get_kernel_peaks", False)
         self.save_kernels = options.get_bool(option_section, "save_kernels", False)
-        ### JMedit Nov 6, 2024
-        # get the growth rate f(z) from previous datablock calculations
-        # instead of by taking a spline derivative of tabulated P(k,z)
+
+        # Do we want to get the growth rate f(z) from previous datablock calculations
+        # or  by taking a spline derivative of tabulated P(k,z)?
         self.fz_from_block = options.get_bool(option_section, "fz_from_block", False)
-        ### end of JMedit
+
         self.limber_ell_start = options.get_int(option_section, "limber_ell_start", 300)
         do_exact_string = options.get_string(option_section, "do_exact", "")
         if do_exact_string=="":
@@ -1609,9 +1605,7 @@ class SpectrumCalculator(object):
                 print(f"Loading {power.section_name} 3D power spectrum")
             power.load_from_block(block, self.chi_of_z)
             if do_exact:
-                ### JMedit Nov 6, 2024, adding fz_from_block argument
                 power.set_nonlimber_splines(block, self.chi_of_z, fz_from_block = self.fz_from_block)
-                ### end of JMedit
             power_key = (powertype, suffix)
             self.power[power_key] = power
 


### PR DESCRIPTION
I've implemented an alternative way to get the growth rate f(z) used to compute RSD contributions to galaxy clustering when doing an exact nonlimber projection calculation. 

The existing code's behavior is that at the lowest available k, P(k_min,z) is tabulated, fit with a spline, and a derivative is taken to get f(chi). In some cases, paticularly with massive neutrinos or cosmological models with scale dependent growth effects, this f(chi) [or f(z)] may not be consistent with the calculation performed by CAMB or other boltzman codes, which compute f(z) using density-velocity cross power. 

To make the RSD prediction for projected galaxy clustering consistent with other parts of the pipeline using the growth rate, it may be preferable to just read f(z) from the datablock, rather than recompute it. That is what this pull request does. 
