### PR TITLE
NERSC updates

### DIFF
--- a/background/astropy_background/astropy_background.py
+++ b/background/astropy_background/astropy_background.py
@@ -100,7 +100,10 @@ def execute(block, config):
 		D_M = D_C
 	else:
 		sqrtOk0 = np.sqrt(abs(Ok0))
-		dh = model._hubble_distance.value
+		try:
+			dh = model._hubble_distance.value
+		except AttributeError:
+			dh = model.hubble_distance.value
 		if Ok0 > 0:
 			D_M = dh / sqrtOk0 * np.sinh(sqrtOk0 * D_C / dh)
 		else:

--- a/likelihood/planck2018/plc-3.0/Makefile
+++ b/likelihood/planck2018/plc-3.0/Makefile
@@ -104,7 +104,7 @@ ODIR := ${PREFIX}/buildir/tmp
 
 # tools
 LD = ${FC}
-INSTALL = install
+INSTALL = cp
 
 # get the os
 UNAME := $(shell uname -s)


### PR DESCRIPTION
This contains changes found to be needed for a recent NERSC install:
- updated astropy changes the name of an attribute for some (not all) models
- the conda env at NERSC breaks the /usr/bin/install command that the Planck likelihood uses, so replace that with `cp`