### PR TITLE
pass extra reionization params to simple tau model

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -242,7 +242,7 @@ def extract_reionization_params(block, config, more_config):
     if more_config["do_reionization"]:
         if more_config['use_optical_depth']:
             tau = block[cosmo, 'tau']
-            reion = camb.reionization.TanhReionization(use_optical_depth=True, optical_depth=tau)
+            reion = camb.reionization.TanhReionization(use_optical_depth=True, optical_depth=tau, **more_config["reionization_params"])
         else:
             sec = 'reionization'
             redshift = block[sec, 'redshift']


### PR DESCRIPTION
This is a simple change to also pass the extra reionization parameters to the tanh model. This can be useful when sampling over large values of tau (> 0.1) that could cause camb to crash if `max_redshift` is set to 50.