### PR TITLE
fixed bug in perbin param name

### DIFF
--- a/shear/add_intrinsic/add_intrinsic.py
+++ b/shear/add_intrinsic/add_intrinsic.py
@@ -69,7 +69,7 @@ def execute(block, config):
         nbin_pos = block[galaxy_shear, 'nbin_a']
 
     if perbin:
-        A = [block[parameters, "A{}".format(i + 1)]
+        A = [block[parameters, "A1_{}".format(i + 1)]
              for i in range(nbin_shear)]
     else:
         A = [1 for i in range(nbin_shear)]


### PR DESCRIPTION
changed the name of the perbin IA amplitude parameters so that a1_1 is not confused anymore by the code with the power-law a1 parameter.