### PR TITLE
fixed missing import numpy in bbn likelihood

### DIFF
--- a/likelihood/bbn/bbn_ombh2.py
+++ b/likelihood/bbn/bbn_ombh2.py
@@ -1,3 +1,4 @@
+import numpy as np
 from cosmosis.datablock import names
 from cosmosis.gaussian_likelihood import SingleValueGaussianLikelihood
 


### PR DESCRIPTION
This pull request introduces a small change to the `likelihood/bbn/bbn_ombh2.py` file. 
The change adds an import statement for `numpy` to ensure its functionality works with `pitrou_cooke_combined` case.