### PR TITLE
Update class interface

### DIFF
--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -85,7 +85,7 @@ def get_N_ur(nmassive):
     elif nmassive == 2:
         return 1.0176
     elif nmassive == 3:
-        return 0.0044
+        return 0.00441
     else:
         raise ValueError(f"Invalid number of massive neutrinos: {nmassive}. "
                          "Must be 0, 1, 2, or 3.")

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -218,6 +218,14 @@ def get_class_outputs(block, c, config):
     h_z = np.array([c.Hubble(zi) for zi in z])
     block[distances, 'H'] = h_z
 
+    # Save the comoving distance
+    d_c = np.array([c.comoving_distance(zi) for zi in z])
+    block[distances, 'd_c'] = d_c
+
+    # Save angular average of comoving angular diameter and line of sight distance, like in camb
+    d_v = ((1 + z)**2 * z * d_a**2 / h_z)**(1./3.)
+    block[distances, 'd_v'] = d_v
+
     mu = np.zeros(z.size)
     mu[0] = -np.inf
     mu[1:] = 5.0 * np.log10(d_l[1:]) + 25.0

--- a/boltzmann/class/class_interface.py
+++ b/boltzmann/class/class_interface.py
@@ -243,6 +243,12 @@ def get_class_outputs(block, c, config):
         for s in ['tt', 'ee', 'te', 'bb']:
             block[cmb_cl, s] = c_ell_data[s][2:] * f
 
+        # save the lensing potential power spectrum
+        if config['lensing']:
+            f_lens = ell * (ell + 1.0) / 2 / np.pi
+            for s in ['pp', 'tp']:
+                block[cmb_cl, s] = c_ell_data[s][2:] * f_lens
+
 
 def execute(block, config):
     import classy

--- a/boltzmann/class/module.yaml
+++ b/boltzmann/class/module.yaml
@@ -123,6 +123,12 @@ outputs:
         d_l:
             meaning: Luminosity distance in Mpc
             type: real 1d
+        d_c: 
+            meaning: Comoving Distance in Mpc 
+            type: real 1d
+        d_v: 
+            meaning: Angular average of comoving angular diameter and line of sight distance
+            type: real 1d
         age:
             meaning: Age of universe in GYr
             type: real
@@ -158,4 +164,10 @@ outputs:
         te:
             meaning: ell * (ell+1) C_ell^TE / 2 pi in mu K^2. Only if mode=cmb or
                 all
+            type: real 1d
+        pp:
+            meaning: ell*(ell+1) C_ell^PhiPhi / 2pi. The CMB lensing power spectra. Only if lensing=True.
+            type: real 1d
+        tp:
+            meaning: ell*(ell+1) C_ell^PhiT / 2pi. CMB Lensing cross-correlations with temperature. Only if lensing=True.
             type: real 1d

--- a/boltzmann/class/module.yaml
+++ b/boltzmann/class/module.yaml
@@ -105,6 +105,10 @@ inputs:
             meaning: The CMB temperature today in Kelvin
             type: real
             default: 2.726
+        N_ur:
+            meaning: Number of ultra-relativistic species. If not given, calculates it from `num_massive_neutrinos` and `nnu` based on the values suggest by CLASS such that N_eff = 3.044.
+            type: real
+            default: get_N_ur()
 outputs:
     cosmological_parameters:
         sigma_8:

--- a/boltzmann/class/module.yaml
+++ b/boltzmann/class/module.yaml
@@ -59,10 +59,14 @@ params:
         meaning: Whether to compute matter power spectra
         type: bool
         default: True
-    cmb:
+    lensing:
         meaning: Whether to lens the output CMB power spectra
         type: bool
         default: True
+    background_only:
+        meaning: Run the class module on background only mode. If set to true, it will not calculate any perturbations.
+        type: bool
+        default: False
     debug:
         meaning: Whether to give a fuller traceback on errors
         type: bool

--- a/examples/desi_dr2_class.ini
+++ b/examples/desi_dr2_class.ini
@@ -1,0 +1,46 @@
+[runtime]
+sampler = test
+verbosity = quiet
+resume = T
+
+[pipeline]
+modules =  consistency class sample_rdh desi
+timing=F
+extra_output = distances/rs_zdrag distances/h0rd
+values = examples/desi-values.ini
+
+[emcee]
+walkers = 32
+samples = 300
+nsteps = 10
+
+[maxlike]
+max_posterior = T
+
+[test]
+save_dir=output/desi
+fatal_errors=T
+
+[output]
+filename = output/desi2.txt
+
+[sample_rdh]
+file = utility/rescale_distances_rdh/rescale_distances_rdh.py
+
+[consistency]
+file = utility/consistency/consistency_interface.py
+
+[class]
+file = boltzmann/class/class_interface.py
+version = 3.2.5
+lmax = 2850
+debug = F
+zmax = 3.0
+cmb = F
+mpk = F
+lensing = F
+background_only = T
+
+[desi]
+file = likelihood/bao/desi-dr2/desi_dr2.py
+desi_data_sets = all


### PR DESCRIPTION
This pull request introduces enhancements to the `boltzmann/class/class_interface.py` module and related configuration files. The changes focus on adding support for a "background-only" mode, improving cosmological parameter handling, and updating outputs for better usability. Additionally, a new example configuration file (`examples/desi_dr2_class.ini`) has been added to demonstrate the functionality. Below is a summary of the most important changes grouped by theme.

### Background-only mode support:

* Added a `background_only` configuration option to run the module without calculating perturbations. An assertion ensures `background_only` cannot be used simultaneously with `cmb` or `mpk`. (`boltzmann/class/class_interface.py`, [[1]](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baR44-R50); `boltzmann/class/module.yaml`, [[2]](diffhunk://#diff-a40e3a68d5a73983d6f0cafea6305e410d1498889957c78c38fb0bf2ea552273L62-R69)
* Updated the `execute` method to skip perturbation calculations when `background_only` is enabled. (`boltzmann/class/class_interface.py`, [boltzmann/class/class_interface.pyL256-R304](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baL256-R304))

### Cosmological parameter handling:

* Introduced the `get_N_ur` function to compute the number of ultra-relativistic species (`N_ur`) based on the number of massive neutrinos (`num_massive_neutrinos`). (`boltzmann/class/class_interface.py`, [boltzmann/class/class_interface.pyR74-R97](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baR74-R97))
* Modified the default value of `nnu` to 3.044, aligning with the standard model of cosmology. (`boltzmann/class/class_interface.py`, [boltzmann/class/class_interface.pyL85-R109](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baL85-R109))
* Added `N_ur` as an input parameter in `module.yaml`, with automatic calculation based on `num_massive_neutrinos` and `nnu`. (`boltzmann/class/module.yaml`, [boltzmann/class/module.yamlR108-R111](diffhunk://#diff-a40e3a68d5a73983d6f0cafea6305e410d1498889957c78c38fb0bf2ea552273R108-R111))

### Output enhancements:

* Added new outputs: `d_c` (comoving distance), `d_v` (angular average of distances), and CMB lensing spectra (`pp`, `tp`). (`boltzmann/class/class_interface.py`, [[1]](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baR270-L244); `boltzmann/class/module.yaml`, [[2]](diffhunk://#diff-a40e3a68d5a73983d6f0cafea6305e410d1498889957c78c38fb0bf2ea552273R134-R139) [[3]](diffhunk://#diff-a40e3a68d5a73983d6f0cafea6305e410d1498889957c78c38fb0bf2ea552273R176-R181)
* Refactored the `get_class_outputs` method to conditionally handle CMB and matter power spectrum outputs based on the `background_only` flag. (`boltzmann/class/class_interface.py`, [[1]](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baR179) [[2]](diffhunk://#diff-d4d4530bf7cfd75701a072ce4b56d3b804f7f3af126a36a50edceca6f18a76baR221-R244)

### Example configuration:

* Added `examples/desi_dr2_class.ini`, showcasing the usage of the `background_only` mode and other features in a DESI pipeline example. (`examples/desi_dr2_class.ini`, [examples/desi_dr2_class.iniR1-R46](diffhunk://#diff-5073470567dc3addb71d0ab8ddbe27dc0c107b8cd56d26861f24cc739a586e84R1-R46))

Closes https://github.com/joezuntz/cosmosis-standard-library/issues/169