### PR TITLE
add act dr6 lite likehood and example

### DIFF
--- a/examples/act-dr6-lite.ini
+++ b/examples/act-dr6-lite.ini
@@ -1,0 +1,55 @@
+[runtime]
+sampler = test
+root = ${PWD}
+verbosity = standard
+resume = T
+
+[test]
+save_dir=output/act
+fatal_errors=T
+
+[output]
+filename = output/act-lite.txt
+
+[maxlike]
+maxiter = 1000
+tolerance = 0.01
+max_posterior = T
+
+[nautilus]
+n_live = 2000
+
+
+[pipeline]
+; these names refer to sections later in the file:
+modules = consistency camb act
+values = examples/act-lite-values.ini
+priors = examples/act-lite-priors.ini
+debug=T
+timing=F
+
+
+[act]
+;Planck 2018 high ell TT,TE and EE + low ell TT + low ell EE (in Planck notations = TT+lowE)
+;without CMB lensing
+file = likelihood/act-dr6-lite/act_dr6_lite_interface.py
+
+
+; The consistency module translates between our chosen parameterization
+; and any other that modules in the pipeline may want (e.g. camb)
+[consistency]
+file = ./utility/consistency/consistency_interface.py
+cosmomc_theta = T
+
+
+[camb]
+file = boltzmann/camb/camb_interface.py
+mode = cmb
+lmax = 8500          ;max ell to use for cmb calculation
+feedback=0         ;amount of output to print
+AccuracyBoost=1.1 ;CAMB accuracy boost parameter
+do_tensors = True   ;include tensor modes
+do_lensing = true    ;lensing is required w/ Planck data
+NonLinear = lens
+accurate_massive_neutrino_transfers = T
+theta_H0_range = "20 100"

--- a/examples/act-lite-priors.ini
+++ b/examples/act-lite-priors.ini
@@ -1,0 +1,3 @@
+[act_params]
+A_act = gaussian 1.0 0.1 
+P_act = gaussian 1.0 0.1

--- a/examples/act-lite-values.ini
+++ b/examples/act-lite-values.ini
@@ -1,0 +1,32 @@
+[cosmological_parameters]
+cosmomc_theta = 1.039  1.04056   1.042 ; this is actually 100 * theta_mc
+omega_k = 0.0     ;spatial curvature
+ombh2 = 0.0218  0.022383  0.02317
+omch2 = 0.1154  0.12011 0.1322
+
+;neutrinos
+mnu = 0.06
+nnu = 3.046
+num_massive_neutrinos = 1
+
+;helium 
+yhe = 0.245341  ;helium mass fraction
+
+;reionization
+tau = 0.035  0.0543  0.075      ;reionization optical depth
+
+;inflation Parameters
+n_s = 0.945  0.96605  0.99      ;scalar spectral index
+log1e10As =  3.0  3.0448  3.105 ; structure amplitude parameter
+k_s = 0.05      ;Power spectrum pivot scale 
+n_run = 0.0     ;running of scalar spectrum 
+r_t = 0.0       ;tensor to scalar ratio
+n_t = 0.0       ;tensor spectral index 
+
+;dark energy equation of state
+w = -1.0   ;equation of state of dark energy
+wa = 0.0   ;equation of state of dark energy (redshift dependency)
+
+[act_params]
+A_act = 0.5 1.0 1.5
+P_act = 0.1 1.0 1.1

--- a/likelihood/act-dr6-lite/act_dr6_lite_interface.py
+++ b/likelihood/act-dr6-lite/act_dr6_lite_interface.py
@@ -1,0 +1,43 @@
+try:
+    import act_dr6_cmbonly
+except ImportError:
+    raise RuntimeError('The act_dr6_cmbonly python module is required for the act_dr6_lite likelihood.')
+from cosmosis.datablock import names
+cosmo = names.cosmological_parameters
+import numpy as np
+import os
+
+
+cal_params = [
+    "A_act",
+    "P_act"
+]
+
+dirname = os.path.split(__file__)[0]
+
+
+def setup(options):
+    act = act_dr6_cmbonly.ACTDR6CMBonly(packages_path=dirname)
+    return act
+
+
+def execute(block, config):
+    act = config
+
+    cl_dict = {
+        "tt": block[names.cmb_cl, 'tt'],
+        "te": block[names.cmb_cl, 'te'],
+        "ee": block[names.cmb_cl, 'ee'],
+    }
+
+    nuisance = {}
+
+    for p in cal_params:
+        nuisance[p] = block["act_params", p]
+    
+    loglike = act.loglike(cl_dict, **nuisance)
+
+    # Then call the act code
+    block[names.likelihoods, 'act_dr6_lite_like'] = loglike
+
+    return 0

--- a/likelihood/act-dr6-lite/get-act-lite-data.sh
+++ b/likelihood/act-dr6-lite/get-act-lite-data.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+pushd "$(dirname "$0")"
+if [ -d data/ACTDR6CMBonly/v1.0 ]
+then
+    echo ACT DR6 Lite data already downloaded
+else
+    wget https://lambda.gsfc.nasa.gov/data/act/pspipe/sacc_files/dr6_data_cmbonly.tar.gz
+    tar -zxvf dr6_data_cmbonly.tar.gz
+    mkdir -p data/ACTDR6CMBonly/v1.0
+    mv v1.0/dr6_data_cmbonly.fits data/ACTDR6CMBonly/v1.0
+    rm dr6_data_cmbonly.tar.gz
+fi
+popd

--- a/likelihood/act-dr6/act_dr6_interface.py
+++ b/likelihood/act-dr6/act_dr6_interface.py
@@ -2,7 +2,7 @@ try:
     import act_dr6_mflike
     import mflike
 except ImportError:
-    raise RuntimeError('The act_dr6_lenslike python module is required for the act_dr6_like likelihood. Try running: pip install act_dr6_mflike.')
+    raise RuntimeError('The act_dr6_mflike python module is required for the act_dr6_like likelihood. Try running: pip install act_dr6_mflike.')
 from cosmosis.datablock import names
 cosmo = names.cosmological_parameters
 import numpy as np

--- a/likelihood/act-dr6/act_dr6_interface.py
+++ b/likelihood/act-dr6/act_dr6_interface.py
@@ -2,7 +2,7 @@ try:
     import act_dr6_mflike
     import mflike
 except ImportError:
-    raise RuntimeError('The act_dr6_lenslike python module is required for the act_dr6_lenslike likelihood. Try running: pip install act_dr6_lenslike.')
+    raise RuntimeError('The act_dr6_lenslike python module is required for the act_dr6_like likelihood. Try running: pip install act_dr6_mflike.')
 from cosmosis.datablock import names
 cosmo = names.cosmological_parameters
 import numpy as np


### PR DESCRIPTION
Adds the [ACT DR6 lite](https://github.com/ACTCollaboration/DR6-ACT-lite) (act_dr6_cmbonly) likelihood from @htjense along with an example. Also fixes some error text in the full act_dr6_mflike likelihood.