### PR TITLE
Correct z=0 index in transfer function

### DIFF
--- a/boltzmann/camb/camb_interface.py
+++ b/boltzmann/camb/camb_interface.py
@@ -585,9 +585,11 @@ def save_matter_power(r, block, more_config):
         # Note that the transfer function has different k range and precision as
         # there is no interpolating function for it in CAMB.
         # We might consider creating an interpolator ...
+        # Note here, that like in the returned sigma_8 and fsigma_8, the redshifts here are reversed
+        # thus for a redshift=0 transfer function we ask for the last element
         section_name_transfer = matter_power_section_names[transfer_type] + "_transfer_func"
-        transfer_func = r.get_matter_transfer_data().transfer_z(tt)
-        k_transfer_func = r.get_matter_transfer_data().transfer_z("k/h")
+        transfer_func = r.get_matter_transfer_data().transfer_z(tt, -1)
+        k_transfer_func = r.get_matter_transfer_data().transfer_z("k/h", -1)
         block.put_double_array_1d(section_name_transfer, "k_h", k_transfer_func)
         block.put_double_array_1d(section_name_transfer, "t_k", transfer_func)
 


### PR DESCRIPTION
This bug went under my radar for a bit, as I performed tests at z=0 and only now when checking for z!=0 cases I have seen that the returned transfer function is not correct. As per the extended comment, same as the sigma_8 and fsigma_8 from CAMB, the transfer function also has the redshift order reversed. Thus to get the transfer function at z=0 we need to ask for the last index.