### PR TITLE
Add DECam13k likelihood

### DIFF
--- a/examples/decam-13k-priors.ini
+++ b/examples/decam-13k-priors.ini
@@ -4,7 +4,7 @@ bias_2 = gaussian 0.00 0.015
 bias_3 = gaussian 0.00 0.011
 bias_4 = gaussian 0.0  0.017
 
-[wl_photoz_errors_delve]
+[wl_photoz_errors_ngc]
 bias_1 = gaussian 0.00 0.01628928605657259
 bias_2 = gaussian 0.00 0.013917589360647912
 bias_3 = gaussian 0.00 0.010112289703644781
@@ -22,7 +22,7 @@ m2 = gaussian -0.0198 0.0078
 m3 = gaussian -0.0241 0.0076
 m4 = gaussian -0.0369 0.0076
 
-[shear_calibration_parameters_delve]
+[shear_calibration_parameters_ngc]
 m1 = gaussian -0.00923 0.00296
 m2 = gaussian -0.01895 0.00421
 m3 = gaussian -0.04004 0.00428

--- a/examples/decam-13k-priors.ini
+++ b/examples/decam-13k-priors.ini
@@ -1,0 +1,35 @@
+[wl_photoz_errors_des]
+bias_1 = gaussian 0.00 0.018
+bias_2 = gaussian 0.00 0.015
+bias_3 = gaussian 0.00 0.011
+bias_4 = gaussian 0.0  0.017
+
+[wl_photoz_errors_delve]
+bias_1 = gaussian 0.00 0.01628928605657259
+bias_2 = gaussian 0.00 0.013917589360647912
+bias_3 = gaussian 0.00 0.010112289703644781
+bias_4 = gaussian 0.00 0.01172302039213366
+
+[wl_photoz_errors_sgc]
+bias_1 = gaussian 0.00 0.01613717713194705999
+bias_2 = gaussian 0.00 0.01403112254514659631
+bias_3 = gaussian 0.00 0.01008882950142993284
+bias_4 = gaussian 0.00 0.01168138157066167526
+
+[shear_calibration_parameters_des]
+m1 = gaussian -0.0063 0.0091
+m2 = gaussian -0.0198 0.0078
+m3 = gaussian -0.0241 0.0076
+m4 = gaussian -0.0369 0.0076
+
+[shear_calibration_parameters_delve]
+m1 = gaussian -0.00923 0.00296
+m2 = gaussian -0.01895 0.00421
+m3 = gaussian -0.04004 0.00428
+m4 = gaussian -0.03733 0.00462
+
+[shear_calibration_parameters_sgc]
+m1 = gaussian -0.0133 0.00472
+m2 = gaussian -0.0226 0.00657
+m3 = gaussian -0.0367 0.00697
+m4 = gaussian -0.0572 0.00804

--- a/examples/decam-13k-values.ini
+++ b/examples/decam-13k-values.ini
@@ -22,7 +22,7 @@ m2 = -0.1  0.0  0.1
 m3 = -0.1  0.0  0.1
 m4 = -0.1  0.0  0.1
 
-[shear_calibration_parameters_delve]
+[shear_calibration_parameters_ngc]
 m1 = -0.1  0.0  0.1
 m2 = -0.1  0.0  0.1 
 m3 = -0.1  0.0  0.1
@@ -40,7 +40,7 @@ bias_2 = -0.1   0.0   0.1
 bias_3 = -0.1   0.0   0.1
 bias_4 = -0.1   0.0   0.1
 
-[wl_photoz_errors_delve]
+[wl_photoz_errors_ngc]
 bias_1 = -0.1   0.0   0.1
 bias_2 = -0.1   0.0   0.1
 bias_3 = -0.1   0.0   0.1
@@ -60,7 +60,7 @@ alpha1  = -4.0  -1.7  4.0
 alpha2  = -4.0  -2.5  4.0
 bias_ta =  0.0   1.0  2.0
 
-[intrinsic_alignment_parameters_delve]
+[intrinsic_alignment_parameters_ngc]
 z_piv   =  0.62
 A1      = -4.0   0.7  4.0
 A2      = -4.0  -1.36 4.0 

--- a/examples/decam-13k-values.ini
+++ b/examples/decam-13k-values.ini
@@ -1,0 +1,77 @@
+[cosmological_parameters]
+omega_m      =  0.1     0.27    0.9
+h0           =  0.55    0.69    0.91
+omega_b      =  0.03    0.048   0.07
+n_s          =  0.87    0.97    1.07
+A_s          =  0.5e-09 2.0e-09 5.0e-09
+w            =  -1.0
+wa           =  0.0
+
+; Old parameter names but backwards compatible 
+; with new setup
+omnuh2       =  0.0006  0.00083 0.00644
+massive_nu   =  3
+massless_nu  =  0.046
+
+omega_k      =  0.0
+tau          =  0.0697186
+
+[shear_calibration_parameters_des]
+m1 = -0.1  0.0  0.1
+m2 = -0.1  0.0  0.1 
+m3 = -0.1  0.0  0.1
+m4 = -0.1  0.0  0.1
+
+[shear_calibration_parameters_delve]
+m1 = -0.1  0.0  0.1
+m2 = -0.1  0.0  0.1 
+m3 = -0.1  0.0  0.1
+m4 = -0.1  0.0  0.1
+
+[shear_calibration_parameters_sgc]
+m1 = -0.1  0.0  0.1
+m2 = -0.1  0.0  0.1 
+m3 = -0.1  0.0  0.1
+m4 = -0.1  0.0  0.1
+
+[wl_photoz_errors_des]
+bias_1 = -0.1   0.0   0.1
+bias_2 = -0.1   0.0   0.1
+bias_3 = -0.1   0.0   0.1
+bias_4 = -0.1   0.0   0.1
+
+[wl_photoz_errors_delve]
+bias_1 = -0.1   0.0   0.1
+bias_2 = -0.1   0.0   0.1
+bias_3 = -0.1   0.0   0.1
+bias_4 = -0.1   0.0   0.1
+
+[wl_photoz_errors_sgc]
+bias_1 = -0.1   0.0   0.1
+bias_2 = -0.1   0.0   0.1
+bias_3 = -0.1   0.0   0.1
+bias_4 = -0.1   0.0   0.1
+
+[intrinsic_alignment_parameters_des]
+z_piv   =  0.62
+A1      = -4.0   0.7  4.0
+A2      = -4.0  -1.36 4.0 
+alpha1  = -4.0  -1.7  4.0
+alpha2  = -4.0  -2.5  4.0
+bias_ta =  0.0   1.0  2.0
+
+[intrinsic_alignment_parameters_delve]
+z_piv   =  0.62
+A1      = -4.0   0.7  4.0
+A2      = -4.0  -1.36 4.0 
+alpha1  = -4.0  -1.7  4.0
+alpha2  = -4.0  -2.5  4.0
+bias_ta =  0.0   1.0  2.0
+
+[intrinsic_alignment_parameters_sgc]
+z_piv   =  0.62
+A1      = -4.0   0.7  4.0
+A2      = -4.0  -1.36 4.0 
+alpha1  = -4.0  -1.7  4.0
+alpha2  = -4.0  -2.5  4.0
+bias_ta =  0.0   1.0  2.0

--- a/examples/decam-13k.ini
+++ b/examples/decam-13k.ini
@@ -9,8 +9,8 @@ verbosity = standard
 ; put in the DEFAULT section and is referenced below as %(2PT_FILE)s
 [DEFAULT]   
 2PT_FILE_DES   = ${COSMOSIS_DIR}/likelihood/des-y3/2pt_NG_final_2ptunblind_02_26_21_wnz_maglim_covupdate.fits
-2PT_FILE_NGC   = ${COSMOSIS_DIR}/likelihood/2pt_decade_ngc_20241128.fits
-2PT_FILE_SGC   = ${COSMOSIS_DIR}/likelihood/2pt_decade_sgc_20250218.fits
+2PT_FILE_NGC   = ${COSMOSIS_DIR}/likelihood/decade/2pt_decade_ngc_20241128.fits
+2PT_FILE_SGC   = ${COSMOSIS_DIR}/likelihood/decade/2pt_decade_sgc_20250218.fits
 
 [pipeline]
 modules =  consistency bbn_consistency
@@ -41,6 +41,15 @@ extra_output = cosmological_parameters/sigma_8 cosmological_parameters/sigma_12
 fast_slow = F
 first_fast_module = 
 
+[polychord]
+resume = F
+feedback = 3
+fast_fraction = 0.1
+
+;Settings for paper runs
+live_points = 500
+num_repeats=100
+tolerance=0.01
 
 [output]
 filename = ${OUTDIR}/decam-13k.txt

--- a/examples/decam-13k.ini
+++ b/examples/decam-13k.ini
@@ -1,0 +1,369 @@
+; This is a cosmic shear only analysis using DECADE NGC
+; DECADE SGC, and DES Y3. We do not use shear ratios
+; when analyzing DES Y3.
+[runtime]
+sampler   = polychord
+verbosity = standard
+
+; This parameter is used several times in this file, so is
+; put in the DEFAULT section and is referenced below as %(2PT_FILE)s
+[DEFAULT]   
+2PT_FILE_DES   = ${COSMOSIS_DIR}/likelihood/des-y3/2pt_NG_final_2ptunblind_02_26_21_wnz_maglim_covupdate.fits
+2PT_FILE_NGC   = ${COSMOSIS_DIR}/likelihood/2pt_decade_ngc_20241128.fits
+2PT_FILE_SGC   = ${COSMOSIS_DIR}/likelihood/2pt_decade_sgc_20250218.fits
+
+[pipeline]
+modules =  consistency bbn_consistency
+           camb fast_pt
+           load_nz_fits_des         load_nz_fits_ngc         load_nz_fits_sgc
+           source_photoz_bias_des   source_photoz_bias_ngc   source_photoz_bias_sgc
+           IA_des                   IA_ngc                   IA_sgc
+           pk_to_cl_des             pk_to_cl_ngc             pk_to_cl_sgc
+           add_intrinsic_des        add_intrinsic_ngc        add_intrinsic_sgc 
+           2pt_shear_des            2pt_shear_ngc            2pt_shear_sgc
+           shear_m_bias_des         shear_m_bias_ngc         shear_m_bias_sgc
+           2pt_des_like             2pt_ngc_like             2pt_sgc_like
+          
+likelihoods = 2pt_des 2pt_ngc 2pt_sgc
+timing=F
+debug=F
+priors = ${COSMOSIS_DIR}/examples/decam-13k-priors.ini
+values = ${COSMOSIS_DIR}/examples/decam-13k-values.ini
+extra_output = cosmological_parameters/sigma_8 cosmological_parameters/sigma_12 
+               data_vector/2pt_des_chi2 data_vector/2pt_ngc_chi2 data_vector/2pt_sgc_chi2
+               likelihoods/2pt_des_like likelihoods/2pt_ngc_like likelihoods/2pt_sgc_like 
+               data_vector/desi_bao_chi2 data_vector/desy5sn_chi2 likelihoods/desi_bao_like likelihoods/desy5sn_like
+
+
+; It's worth switching this to T when sampling using multinest, polychord,
+; or other samplers that can take advantage of differences in calculation speeds between
+; different parameters.
+fast_slow = F
+first_fast_module = 
+
+
+[output]
+filename = ${OUTDIR}/decam-13k.txt
+format   = text
+
+[consistency]
+file = ${COSMOSIS_DIR}/utility/consistency/consistency_interface.py
+
+[camb]
+file = ${COSMOSIS_DIR}/boltzmann/camb/camb_interface.py
+mode = power
+lmax = 2500          ;max ell to use for cmb calculation
+feedback=0         ;amount of output to print
+AccuracyBoost=1.1 ;CAMB accuracy boost parameter
+do_tensors = T
+do_lensing = T
+NonLinear = pk
+halofit_version = mead2020
+zmin_background = 0.
+zmax_background = 5.
+nz_background = 401
+kmin=1e-4
+kmax = 50.0
+kmax_extrapolate = 500.0
+nk=700
+
+[bbn_consistency]
+file = ${COSMOSIS_DIR}/utility/bbn_consistency/bbn_consistency.py
+
+[load_nz_fits_des]
+file = ${REPO_DIR}/modules/load_nz_fits.py
+nz_file = %(2PT_FILE_DES)s
+data_sets = source 
+data_sets_output = des
+
+[load_nz_fits_ngc]
+file = ${REPO_DIR}/modules/load_nz_fits.py
+nz_file = %(2PT_FILE_NGC)s
+data_sets = source                
+data_sets_output = ngc
+
+[load_nz_fits_sgc]
+file = ${REPO_DIR}/modules/load_nz_fits.py
+nz_file = %(2PT_FILE_SGC)s
+data_sets = source                
+data_sets_output = sgc
+ 
+[source_photoz_bias_des]
+file = ${COSMOSIS_DIR}/number_density/photoz_bias/photoz_bias.py
+mode = additive
+sample = nz_des
+bias_section = wl_photoz_errors_des
+interpolation = linear
+
+[source_photoz_bias_ngc]
+file = ${COSMOSIS_DIR}/number_density/photoz_bias/photoz_bias.py
+mode = additive
+sample = nz_ngc
+bias_section = wl_photoz_errors_ngc
+interpolation = linear
+
+[source_photoz_bias_sgc]
+file = ${COSMOSIS_DIR}/number_density/photoz_bias/photoz_bias.py
+mode = additive
+sample = nz_sgc
+bias_section = wl_photoz_errors_sgc
+interpolation = linear
+
+[fast_pt]
+file = ${COSMOSIS_DIR}/structure/fast_pt/fast_pt_interface.py
+do_ia = T
+k_res_fac = 0.5
+verbose = F
+
+[IA_des]
+file = ${COSMOSIS_DIR}/intrinsic_alignments/tatt/tatt_interface.py
+sub_lowk = F
+do_galaxy_intrinsic = F
+ia_model = tatt
+name=des
+param_name=des
+
+[IA_ngc]
+file = ${COSMOSIS_DIR}/intrinsic_alignments/tatt/tatt_interface.py
+sub_lowk = F
+do_galaxy_intrinsic = F
+ia_model = tatt
+name=ngc
+param_name=ngc
+
+[IA_sgc]
+file = ${COSMOSIS_DIR}/intrinsic_alignments/tatt/tatt_interface.py
+sub_lowk = F
+do_galaxy_intrinsic = F
+ia_model = tatt
+name=sgc
+param_name=sgc
+
+[pk_to_cl_des]
+file = ${COSMOSIS_DIR}/structure/projection/project_2d.py
+ell_min_logspaced = 0.1
+ell_max_logspaced = 5.0e5
+n_ell_logspaced = 100 
+shear-shear = des-des:des:des
+shear-intrinsic = des-des:des:des
+intrinsic-intrinsic = des-des:des:des
+intrinsicb-intrinsicb= des-des:des:des
+verbose = F
+get_kernel_peaks = F
+sig_over_dchi = 20. 
+shear_kernel_dchi = 10.
+
+[pk_to_cl_ngc]
+file = ${COSMOSIS_DIR}/structure/projection/project_2d.py
+ell_min_logspaced = 0.1
+ell_max_logspaced = 5.0e5
+n_ell_logspaced = 100
+shear-shear = ngc-ngc:ngc:ngc
+shear-intrinsic = ngc-ngc:ngc:ngc
+intrinsic-intrinsic = ngc-ngc:ngc:ngc
+intrinsicb-intrinsicb= ngc-ngc:ngc:ngc
+verbose = F
+get_kernel_peaks = F
+sig_over_dchi = 20. 
+shear_kernel_dchi = 10.  
+
+
+[pk_to_cl_sgc]
+file = ${COSMOSIS_DIR}/structure/projection/project_2d.py
+ell_min_logspaced = 0.1
+ell_max_logspaced = 5.0e5
+n_ell_logspaced = 100
+shear-shear = sgc-sgc:sgc:sgc
+shear-intrinsic = sgc-sgc:sgc:sgc
+intrinsic-intrinsic = sgc-sgc:sgc:sgc
+intrinsicb-intrinsicb= sgc-sgc:sgc:sgc
+verbose = F
+get_kernel_peaks = F
+sig_over_dchi = 20. 
+shear_kernel_dchi = 10.  
+
+[add_intrinsic_des]
+file=${COSMOSIS_DIR}/shear/add_intrinsic/add_intrinsic.py
+shear-shear=T
+position-shear=F
+perbin=F
+suffix=des
+
+[add_intrinsic_ngc]
+file=${COSMOSIS_DIR}/shear/add_intrinsic/add_intrinsic.py
+shear-shear=T
+position-shear=F
+perbin=F
+suffix=ngc
+
+[add_intrinsic_sgc]
+file=${COSMOSIS_DIR}/shear/add_intrinsic/add_intrinsic.py
+shear-shear=T
+position-shear=F
+perbin=F
+suffix=sgc
+
+[2pt_shear_des]
+file = ${COSMOSIS_DIR}/shear/cl_to_xi_fullsky/cl_to_xi_interface.py
+ell_max = 40000
+xi_type = EB
+theta_file=%(2PT_FILE_DES)s
+bin_avg = T
+input_section_name = shear_cl_des  shear_cl_bb_des
+output_section_name = shear_xi_plus  shear_xi_minus
+e_plus_b_name = des
+save_name = des
+
+[2pt_shear_ngc]
+file = ${COSMOSIS_DIR}/shear/cl_to_xi_fullsky/cl_to_xi_interface.py
+ell_max = 40000
+xi_type = EB
+theta_file=%(2PT_FILE_NGC)s
+bin_avg = T
+input_section_name = shear_cl_ngc  shear_cl_bb_ngc
+output_section_name = shear_xi_plus  shear_xi_minus
+e_plus_b_name = ngc
+save_name = ngc
+
+[2pt_shear_sgc]
+file = ${COSMOSIS_DIR}/shear/cl_to_xi_fullsky/cl_to_xi_interface.py
+ell_max = 40000
+xi_type = EB
+theta_file=%(2PT_FILE_SGC)s
+bin_avg = T
+input_section_name = shear_cl_sgc  shear_cl_bb_sgc
+output_section_name = shear_xi_plus  shear_xi_minus
+e_plus_b_name = sgc
+save_name = sgc
+
+[shear_m_bias_des]
+file = ${COSMOSIS_DIR}/shear/shear_bias/shear_m_bias.py
+m_per_bin = True
+cl_section = shear_xi_plus_des shear_xi_minus_des
+cal_section = shear_calibration_parameters_des
+cross_section = galaxy_shear_xi
+verbose = F
+
+[shear_m_bias_ngc]
+file = ${COSMOSIS_DIR}/shear/shear_bias/shear_m_bias.py
+m_per_bin = True
+cl_section = shear_xi_plus_ngc shear_xi_minus_ngc
+cal_section = shear_calibration_parameters_ngc
+verbose = F
+
+[shear_m_bias_sgc]
+file = ${COSMOSIS_DIR}/shear/shear_bias/shear_m_bias.py
+m_per_bin = True
+cl_section = shear_xi_plus_sgc shear_xi_minus_sgc
+cal_section = shear_calibration_parameters_sgc
+verbose = F
+
+[2pt_des_like]
+file = ${COSMOSIS_DIR}/likelihood/2pt/2pt_point_mass/2pt_point_mass.py
+do_pm_marg = True
+do_pm_sigcritinv = True
+sigma_a = 10000.0
+no_det_fac = False
+include_norm = True
+data_file = %(2PT_FILE_DES)s
+data_sets = xip xim
+save_name = des
+make_covariance=F
+covmat_name=COVMAT
+suffixes = des
+like_name = 2pt_des
+
+angle_range_xip_1_1 = 2.475 999.0
+angle_range_xip_1_2 = 6.21691892 999.0
+angle_range_xip_1_3 = 6.21691892 999.0
+angle_range_xip_1_4 = 4.93827423 999.0
+angle_range_xip_2_2 = 6.21691892 999.0
+angle_range_xip_2_3 = 6.21691892 999.0
+angle_range_xip_2_4 = 6.21691892 999.0
+angle_range_xip_3_3 = 6.21691892 999.0
+angle_range_xip_3_4 = 6.21691892 999.0
+angle_range_xip_4_4 = 4.93827423 999.0
+angle_range_xim_1_1 = 24.75 999.0
+angle_range_xim_1_2 = 62.16918918 999.0
+angle_range_xim_1_3 = 62.16918918 999.0
+angle_range_xim_1_4 = 49.3827423 999.0
+angle_range_xim_2_2 = 62.16918918 999.0
+angle_range_xim_2_3 = 78.26637209 999.0
+angle_range_xim_2_4 = 78.26637209 999.0
+angle_range_xim_3_3 = 78.26637209 999.0
+angle_range_xim_3_4 = 78.26637209 999.0
+angle_range_xim_4_4 = 62.16918918 999.0
+
+
+[2pt_ngc_like]
+file = ${COSMOSIS_DIR}/likelihood/2pt/2pt_point_mass/2pt_point_mass.py
+do_pm_marg = True
+do_pm_sigcritinv = True
+sigma_a = 10000.0
+no_det_fac = False
+include_norm = True
+data_file = %(2PT_FILE_NGC)s
+data_sets = xip xim
+save_name= ngc
+make_covariance=F
+covmat_name=COVMAT
+suffixes = ngc 
+like_name = 2pt_ngc
+
+angle_range_xip_1_1 = 5.659 999.0
+angle_range_xip_1_2 = 7.124 999.0
+angle_range_xip_1_3 = 7.124 999.0
+angle_range_xip_1_4 = 7.124 999.0
+angle_range_xip_2_2 = 7.124 999.0
+angle_range_xip_2_3 = 7.124 999.0
+angle_range_xip_2_4 = 7.124 999.0
+angle_range_xip_3_3 = 7.124 999.0
+angle_range_xip_3_4 = 7.124 999.0
+angle_range_xip_4_4 = 5.659 999.0
+angle_range_xim_1_1 = 56.586 999.0
+angle_range_xim_1_2 = 56.586 999.0
+angle_range_xim_1_3 = 56.586 999.0
+angle_range_xim_1_4 = 56.586 999.0
+angle_range_xim_2_2 = 56.586 999.0
+angle_range_xim_2_3 = 56.586 999.0
+angle_range_xim_2_4 = 56.586 999.0
+angle_range_xim_3_3 = 56.586 999.0
+angle_range_xim_3_4 = 71.238 999.0
+angle_range_xim_4_4 = 56.586 999.0
+
+
+[2pt_sgc_like]
+file = ${COSMOSIS_DIR}/likelihood/2pt/2pt_point_mass/2pt_point_mass.py
+do_pm_marg = True
+do_pm_sigcritinv = True
+sigma_a = 10000.0
+no_det_fac = False
+include_norm = True
+data_file = %(2PT_FILE_SGC)s
+data_sets = xip xim
+save_name= sgc
+make_covariance=F
+covmat_name=COVMAT
+suffixes = sgc
+like_name = 2pt_sgc
+
+angle_range_xip_1_1 = 5.659 999.0
+angle_range_xip_1_2 = 7.124 999.0
+angle_range_xip_1_3 = 7.124 999.0
+angle_range_xip_1_4 = 7.124 999.0
+angle_range_xip_2_2 = 5.659 999.0
+angle_range_xip_2_3 = 7.124 999.0
+angle_range_xip_2_4 = 7.124 999.0
+angle_range_xip_3_3 = 5.659 999.0
+angle_range_xip_3_4 = 7.124 999.0
+angle_range_xip_4_4 = 5.659 999.0
+angle_range_xim_1_1 = 35.703 999.0
+angle_range_xim_1_2 = 35.703 999.0
+angle_range_xim_1_3 = 35.703 999.0
+angle_range_xim_1_4 = 35.703 999.0
+angle_range_xim_2_2 = 35.703 999.0
+angle_range_xim_2_3 = 44.948 999.0
+angle_range_xim_2_4 = 44.948 999.0
+angle_range_xim_3_3 = 44.948 999.0
+angle_range_xim_3_4 = 44.948 999.0
+angle_range_xim_4_4 = 44.948 999.0

--- a/examples/decam-13k.ini
+++ b/examples/decam-13k.ini
@@ -45,7 +45,8 @@ first_fast_module =
 resume = F
 feedback = 3
 fast_fraction = 0.1
-
+base_dir = ${OUTDIR}/checkpoints
+polychord_outfile_root = decam-13k
 ;Settings for paper runs
 live_points = 500
 num_repeats=100

--- a/intrinsic_alignments/tatt/module.yaml
+++ b/intrinsic_alignments/tatt/module.yaml
@@ -35,6 +35,10 @@ params:
         meaning: Suffix to add to output section names
         type: str
         default: ""
+    param_name:
+        meaning: Suffix to use when searching for ia parameters
+        type: str
+        default: ""
     do_galaxy_intrinsic:
         meaning: Whether to compute galaxy-intrinsic cross power
         type: bool

--- a/intrinsic_alignments/tatt/tatt_interface.py
+++ b/intrinsic_alignments/tatt/tatt_interface.py
@@ -236,6 +236,7 @@ def setup(options):
     sub_lowk = options.get_bool(option_section, "sub_lowk", False)
     ia_model = options.get_string(option_section, "ia_model", "nla")
     name = options.get_string(option_section, "name", default="").lower()
+    param_name = options.get_string(option_section, "param_name", default="").lower()
     do_galaxy_intrinsic = options.get_bool(option_section, "do_galaxy_intrinsic", False)
     no_IA_E = options.get_bool(option_section, "no_IA_E", False)
     no_IA_B = options.get_bool(option_section, "no_IA_B", False)
@@ -244,10 +245,16 @@ def setup(options):
         suffix = "_" + name
     else:
         suffix = ""
+
+    if param_name:
+        param_name = '_' + param_name
+    else:
+        param_name = ""
     return (
         sub_lowk,
         ia_model,
         suffix,
+        param_name,
         do_galaxy_intrinsic,
         no_IA_E,
         no_IA_B,
@@ -259,6 +266,7 @@ def execute(block, config):
         sub_lowk,
         ia_model,
         suffix,
+        param_name,
         do_galaxy_intrinsic,
         no_IA_E,
         no_IA_B,
@@ -287,7 +295,7 @@ def execute(block, config):
     E_factor = 0 if no_IA_E else 1
     B_factor = 0 if no_IA_B else 1
 
-    ia_section = "intrinsic_alignment_parameters"
+    ia_section = "intrinsic_alignment_parameters" + param_name
 
     # check for deprecated parameters
     if (ia_section, "C1") in block:

--- a/number_density/load_nz_fits/load_nz_fits.py
+++ b/number_density/load_nz_fits/load_nz_fits.py
@@ -80,11 +80,15 @@ def load_histogram_form(ext, upsampling):
 def setup(options):
     nz_file = options.get_string(option_section, "nz_file")
     data_sets = options.get_string(option_section, "data_sets")
+    data_sets_output = options.get_string(option_section, "data_sets_output", data_sets) #Allow user to add new output name, but default to regular name
     upsampling = options.get_int(option_section, "upsampling", 1)
     prefix_extension = options.get_bool(
         option_section, "prefix_extension", True)
     prefix_section = options.get_bool(option_section, "prefix_section", True)
+    
     data_sets = data_sets.split()
+    data_sets_output = data_sets_output.split()
+    
     if not data_sets:
         raise RuntimeError(
             "Option data_sets empty; please set the option data_sets=name1 name2 etc and I will search the fits file for nz_name2, nz_name2, etc.")
@@ -96,7 +100,7 @@ def setup(options):
         print("if you do not want this.")
     F = pyfits.open(nz_file)
     data = {}
-    for data_set in data_sets:
+    for data_set, data_set_output in zip(data_sets, data_sets_output):
         try:
             name = "NZ_" + data_set.upper() if prefix_extension else data_set.upper()
             print("    Looking at FITS extension {0}:".format(name))
@@ -107,6 +111,7 @@ def setup(options):
             ext = F[name]
 
         section = "NZ_" + data_set.upper() if prefix_section else data_set.upper()
+        section = section.replace(data_set.upper(), data_set_output.upper()) #Replace original name with new name when writing NZ into the cosmosis datablock/section
         z, nz = load_histogram_form(ext, upsampling)
         data[section] = (z, nz)
     return data

--- a/number_density/load_nz_fits/module.yaml
+++ b/number_density/load_nz_fits/module.yaml
@@ -43,7 +43,10 @@ params:
         default:
     data_sets:
         meaning: Space separated names of the extensions from the FITS files to load
-            and save to the block
+        type: str
+        default:
+    data_sets_output:
+        meaning: Space separated names to use to save the nz to the block
         type: str
         default:
     prefix_extension:


### PR DESCRIPTION
Edits that allow for the combination of DES with DECADE NGC and SGC datavectors. Main updates are in load_nz_fits and tatt_interface, are simply add "suffix" options so you can more easily have multiple named n(z) and (TATT) IA parameters in a single run.

Update also includes the main ini file for the full DECam 13k (DES + DECADE) analysis. Plan to push datavectors in this PR closer to paper publication (early next week).