### PR TITLE
lollipop takes unscaled Cls

### DIFF
--- a/likelihood/cmb/planck/hillipop/hillipop_interface.py
+++ b/likelihood/cmb/planck/hillipop/hillipop_interface.py
@@ -11,7 +11,7 @@ nuisance_parameters = [
     "beta_radio",
     "Adusty",
     "AdustT",
-    "beta_dusty",
+    # "beta_dusty",
     "beta_dustT",
     "AsyncT",
     "Acib",
@@ -38,7 +38,6 @@ nuisance_parameters = [
 ]
 
 def setup(options):
-    raise RuntimeError("We are not quite sure if the Hillipop and Lollipop interfaces are correctly set up yet. You can remove this line to help test.")
     mode = options.get_string(option_section, "mode", default="TTTEEE").upper()
     if mode == "TT":
         calculator = TT()

--- a/likelihood/cmb/planck/lollipop/lollipop_interface.py
+++ b/likelihood/cmb/planck/lollipop/lollipop_interface.py
@@ -11,7 +11,6 @@ nuisance_parameters = [
 ]
 
 def setup(options):
-    raise RuntimeError("We are not quite sure if the Hillipop and Lollipop interfaces are correctly set up yet. You can remove this line to help test.")
     mode = options.get_string(option_section, "mode", default="TTTEEE").lower()
     if mode == "lowle":
         calculator = lowlE()
@@ -39,12 +38,11 @@ def execute(block, config):
     calculator = config
 
     cl = {}
-    cl["ee"] = block['cmb_cl', 'ee']
-    cl["bb"] = block['cmb_cl', 'bb']
-
+    # lollipop wants the actual Cl w/o prefactors
     ell = block['cmb_cl', 'ell']
+    cl["ee"] = block['cmb_cl', 'ee'] * 2*np.pi / (ell * (ell+1))
+    cl["bb"] = block['cmb_cl', 'bb'] * 2*np.pi / (ell * (ell+1))
     make_cl_start_at_zero(cl, ell)
-
 
     nuisance = {}
     for param in nuisance_parameters:


### PR DESCRIPTION
This fixes a bug in the lollipop interface that led to biases in particular on the recovered value of $\tau$.

@sophieMLV reverse-engineered from cobaya that the lollipop likelihood takes the raw Cls, without the l (l+1)/2pi factor.

With this fix, we can reproduce the high-ell TTTEEE (hillipop) + lowT (Planck18) + lowE (lollipop) constraints on a flat nuLCDM cosmology.

<img width="1190" height="1202" alt="image" src="https://github.com/user-attachments/assets/33d6f5bb-41ed-49cc-8a93-813807e9b365" />