### PR TITLE
fix consistency relation with cosmomc_theta as input in non-Lambda DE models

### DIFF
--- a/utility/consistency/theta_h0.py
+++ b/utility/consistency/theta_h0.py
@@ -88,6 +88,7 @@ def theta_to_H0(theta, omnuh2, mnu, TCMB, omch2, ombh2, omega_k, num_massive_neu
     try:
         camb.set_feedback_level(0)
         p = camb.CAMBparams()
+        p.set_dark_energy(w=w, wa=wa, dark_energy_model='ppf')
         p.set_cosmology(ombh2 = ombh2,
                         omch2 = omch2,
                         omk = omega_k,
@@ -95,7 +96,6 @@ def theta_to_H0(theta, omnuh2, mnu, TCMB, omch2, ombh2, omega_k, num_massive_neu
                         num_massive_neutrinos=num_massive_neutrinos,
                         nnu=nnu,
                         cosmomc_theta = theta)
-        p.set_dark_energy(w=w, wa=wa, dark_energy_model='ppf')
         H0 = p.h * 100
     except:
         H0 = np.nan


### PR DESCRIPTION
Using `cosmomc_theta` as input parameter didn't work when w != -1 and/or wa != 0 as it produced inconsistent parameters. In the CAMB documentation of the `set_cosmology` function:
"Note that you must have already set the dark energy model, you can’t use set_cosmology with theta and then change the background evolution (which would change theta at the calculated H0 value)"
Indeed, calling `set_dark_energy` before calling `set_cosmology` fixes the problem.