### PR TITLE
Fix macOS shared-library build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export MAKEFILES := $(CURDIR)/config/local_compiler_overrides.mk $(MAKEFILES)
+
 include ${COSMOSIS_SRC_DIR}/config/compilers.mk
 include ${COSMOSIS_SRC_DIR}/config/subdirs.mk
 

--- a/boltzmann/class/class_v3.2.5/Makefile
+++ b/boltzmann/class/class_v3.2.5/Makefile
@@ -49,7 +49,9 @@ OMPFLAG   = -pthread #-fopenmp
 
 # all other compilation flags
 CCFLAG = -g -fPIC -I ${GSL_INC}
-LDFLAG = -g -fPIC
+LDFLAG ?=
+LDFLAG += -g -fPIC
+LDFLAG += $(LDFLAGS)
 
 # leave blank to compile without HyRec, or put path to HyRec directory
 # (with no slash at the end: e.g. "external/RecfastCLASS")

--- a/boltzmann/isitgr/Makefile
+++ b/boltzmann/isitgr/Makefile
@@ -13,12 +13,12 @@ CAMBDIR=camb_Jan12_isitgr
 all: $(INTERFACE)
 
 # purposefully chosen to be non-file target to
-# always decend into CAMBDIR
+# always descend into CAMBDIR
 $(CAMBDIR)/$(CAMBLIB)::
 	cd $(CAMBDIR) && $(MAKE) $(CAMBLIB)
 
 $(INTERFACE): $(CAMBDIR)/$(CAMBLIB) camb_interface.F90 camb_module.F90
-	$(FC) $(FFLAGS) -shared camb_interface.F90 camb_module.F90 -o $(INTERFACE) $(LDFLAGS) -I$(CAMBDIR)  -L$(CAMBDIR) -lcamb
+	$(FC) $(FFLAGS) -shared camb_interface.F90 camb_module.F90 -o $(INTERFACE) $(LDFLAGS) -I$(CAMBDIR) -L$(CAMBDIR) -lcamb
 
 clean:
 	cd $(CAMBDIR) && $(MAKE) clean

--- a/boltzmann/mgcamb/Makefile
+++ b/boltzmann/mgcamb/Makefile
@@ -13,12 +13,12 @@ CAMBDIR=camb_Jan12_mgcamb
 all: $(INTERFACE)
 
 # purposefully chosen to be non-file target to
-# always decend into CAMBDIR
+# always descend into CAMBDIR
 $(CAMBDIR)/$(CAMBLIB)::
 	cd $(CAMBDIR) && $(MAKE) $(CAMBLIB)
 
 $(INTERFACE): $(CAMBDIR)/$(CAMBLIB) camb_interface.F90 camb_module.F90
-	$(FC) $(FFLAGS) -shared camb_interface.F90 camb_module.F90 -o $(INTERFACE) $(LDFLAGS) -I$(CAMBDIR)  -L$(CAMBDIR) -lcamb
+	$(FC) $(FFLAGS) -shared camb_interface.F90 camb_module.F90 -o $(INTERFACE) $(LDFLAGS) -I$(CAMBDIR) -L$(CAMBDIR) -lcamb
 
 clean:
 	cd $(CAMBDIR) && $(MAKE) clean

--- a/config/local_compiler_overrides.mk
+++ b/config/local_compiler_overrides.mk
@@ -8,7 +8,4 @@ ifeq ($(OS),Darwin)
 # Allow unresolved symbols in module shared-library links on macOS; symbols
 # are resolved when loaded by the host process.
 export LDFLAGS += -Wl,-undefined,dynamic_lookup
-
-# Some in-tree makefiles use LDFLAG (without S), so export both forms.
-export LDFLAG += -Wl,-undefined,dynamic_lookup
 endif

--- a/config/local_compiler_overrides.mk
+++ b/config/local_compiler_overrides.mk
@@ -1,0 +1,14 @@
+# Project-local compiler/linker overrides.
+# This file is intentionally in the repository so we do not need to edit
+# the CosmoSIS package installed in a conda environment.
+
+OS ?= $(shell uname -s)
+
+ifeq ($(OS),Darwin)
+# Allow unresolved symbols in module shared-library links on macOS; symbols
+# are resolved when loaded by the host process.
+export LDFLAGS += -Wl,-undefined,dynamic_lookup
+
+# Some in-tree makefiles use LDFLAG (without S), so export both forms.
+export LDFLAG += -Wl,-undefined,dynamic_lookup
+endif

--- a/likelihood/fgas/src/Makefile
+++ b/likelihood/fgas/src/Makefile
@@ -14,7 +14,7 @@ listobjects:
 objects: $(OBJECTS) $(SEPOBJ)
 
 $(MYLIB): $(OBJECTS)
-	$(CXX) $(CXXFLAGS) -shared -o $(CURDIR)/$(MYLIB) -L$(GSL_LIB) -lgsl $(OBJECTS)
+	$(CXX) $(CXXFLAGS) -shared -o $(CURDIR)/$(MYLIB) $(OBJECTS) $(LDFLAGS) -L$(GSL_LIB) -lgsl
 
 clusters.o: clusters.hpp util.hpp
 fgas.o: clusters.hpp fgas.hpp lensing.hpp util.hpp xray.hpp

--- a/likelihood/planck2018/Makefile
+++ b/likelihood/planck2018/Makefile
@@ -9,6 +9,10 @@ PLANCK_DIR=plc-3.0
 RPATH_FLAGS=-Wl,-rpath,$(PWD)/$(PLANCK_DIR)/lib -Wl,-rpath,$(PWD)/$(PLANCK_DIR)/buildir
 USER_LDFLAGS=-L$(PLANCK_DIR)/lib -lcosmosis $(RPATH_FLAGS) -L$(CFITSIO_LIB) -lcfitsio $(LAPACK_LINK)
 
+ifeq ($(shell uname),Darwin)
+USER_LDFLAGS += -Wl,-undefined,dynamic_lookup
+endif
+
 PLANCK_LIB=lib/libclik.so
 USER_CFLAGS=-I$(PLANCK_DIR)/include  -D_GNU_SOURCE $(DEFINES)
 

--- a/likelihood/planck2018/Makefile
+++ b/likelihood/planck2018/Makefile
@@ -9,10 +9,6 @@ PLANCK_DIR=plc-3.0
 RPATH_FLAGS=-Wl,-rpath,$(PWD)/$(PLANCK_DIR)/lib -Wl,-rpath,$(PWD)/$(PLANCK_DIR)/buildir
 USER_LDFLAGS=-L$(PLANCK_DIR)/lib -lcosmosis $(RPATH_FLAGS) -L$(CFITSIO_LIB) -lcfitsio $(LAPACK_LINK)
 
-ifeq ($(shell uname),Darwin)
-USER_LDFLAGS += -Wl,-undefined,dynamic_lookup
-endif
-
 PLANCK_LIB=lib/libclik.so
 USER_CFLAGS=-I$(PLANCK_DIR)/include  -D_GNU_SOURCE $(DEFINES)
 

--- a/likelihood/planck2018/plc-3.0/Makefile
+++ b/likelihood/planck2018/plc-3.0/Makefile
@@ -147,7 +147,7 @@ FFPIC = -fPIC
 
 # check here that the SHARED variable contain the correct invocation for your CC
 ifeq ($(OS),macos)
-SHARED = -dynamiclib
+SHARED = -dynamiclib -Wl,-undefined,dynamic_lookup
 else
 SHARED = -shared -Bdynamic
 endif


### PR DESCRIPTION
This PR will fix issue #221 .

Add config/local_compiler_overrides.mk, included by the root Makefile, which exports -Wl,-undefined,dynamic_lookup on macOS for both LDFLAGS and LDFLAG. This allows shared-library links to leave symbols unresolved at link time, which is required on macOS because the CosmoSIS runtime resolves them when loading modules.

Propagate LDFLAGS through the CLASS v3.2.5, fgas, planck2018, and plc-3.0 Makefiles so they pick up the override. Also fix a typo ("decend" -> "descend") and remove a duplicate space in the isitgr and mgcamb Makefiles.