### PR TITLE
Added onepower interface to CSL

### DIFF
--- a/structure/onepower/module.yaml
+++ b/structure/onepower/module.yaml
@@ -1,0 +1,732 @@
+name: onepower_interface
+version: Jul2025
+purpose: Calculates power spectra using halo model.
+url: "https://kids-wl.github.io/onepower/"
+interface: onepower_interface.py
+attribution: [Andrej Dvornik, Marika Asgari, Maria-Cristina Fortuna]
+rules:
+    If you use this module then please cite the papers below
+cite:
+    - "https://arxiv.org/abs/2003.02700"
+    - "https://arxiv.org/abs/2210.03110"
+
+assumptions:
+    -
+
+explanation: |
+  A module for calculating 3D power spectra using the halo model approach:
+  See section 2 of https://arxiv.org/pdf/2303.08752.pdf for details
+
+  P_uv = P^2h_uv + P^1h_uv  (1)
+  P^1h_uv (k) = int_0^infty dM Wu(M, k) Wv(M, k) n(M)  (2)
+  P^2h_uv (k) = int_0^infty int_0^infty dM1 dM2 Phh(M1, M2, k) Wu(M1, k) Wv(M2, k) n(M1) n(M2)  (3)
+
+  Wx are the profile of the fields, u and v, showing how they fit into haloes.
+  n(M) is the halo mass function, quantifying the number of haloes of each mass, M.
+  Integrals are taken over halo mass.
+
+  The halo-halo power spectrum can be written as,
+  Phh(M1,M2,k) = b(M1) b(M2) P^lin_mm(k) (1 + beta_nl(M1,M2,k)) (4)
+
+  In the vanilla halo model the 2-halo term is usually simplified by assuming that haloes are linearly biased with respect to matter.
+  This sets beta_nl to zero and effectively decouples the integrals in (3). Here we allow for both options to be calculated.
+
+  Linear matter power spectrum needs to be provided as well.
+
+  Current power spectra that we predict are
+  mm: matter-matter
+  gg: galaxy-galaxy
+  gm: galaxy-matter
+
+  II: intrinsic-intrinsic alignments
+  gI: galaxy-intrinsic alignment
+  mI: matter-intrinsic alignment
+
+  This module has two modes: response and direct
+  If in direct mode it will directly calculate the power spectra
+  If in response mode it will calcualte the reponse of the hm to different power spectra with respect to P_mm
+  and multiply that to an input P_mm to estimate the desired power, for example:
+  res_gg = P^hm_gg/P^hm_mm
+  res_gm = P^hm_gm/P^hm_mm
+  Then uses these in combination with input matter power spectra, P_mm, to create 3D power for P_gg and P_gm
+  P_gg = res_gg P_mm
+  P_gm = res_gm P_mm
+
+# List of parameters that can go in the params.ini file in the section for this module
+params:
+      p_mm:
+          meaning: "if True calculates matter-matter power spectrum. If you want the non-linear matter power spectrum not to be calculated using halo model, use CAMB with the desired non-linear model before this module and set p_mm to False."
+          type: bool
+          default: False
+      p_gm:
+          meaning: "if True calculates matter-galaxy power spectrum."
+          type: bool
+          default: False
+      p_gg:
+          meaning: "if True calculates galaxy-galaxy power spectrum."
+          type: bool
+          default: False
+      p_II:
+          meaning: "if True calculates intrinsic-intrinsic power spectrum."
+          type: bool
+          default: False
+      p_mI:
+          meaning: "if True calculates matter-intrinsic power spectrum."
+          type: bool
+          default: False
+      p_gI:
+          meaning: "if True calculates galaxy-intrinsic power spectrum."
+          type: bool
+          default: False
+      response:
+          meaning: "if True uses the response method to calculate power spectra, if False calculates power spectra directly. See the explanation section for details."
+          type: bool
+          default: False
+      nonlinear_mode:
+          meaning: "if set uses the mode requested. Currently supported options are hmcode, fortuna, bnl and None (default)."
+          type: str
+          default: None
+      split_ia:
+          meaning: "if True it splits the calculation of IA power spectra to red and blue contributions. IA parameters and HOD settings need to be passed for the two different populations, as well as the fractions of red/blue galaxies."
+          type: bool
+          default: False
+      point_mass:
+          meaning: "Include the point mass correction in the P_gm"
+          type: bool
+          default: False
+      dewiggle:
+          meaning: "Apply dewiggling to the P_lin as described in Mead et al. 2020, Crocce & Scoccimarro 2006"
+          type: bool
+          default: False
+      poisson_type:
+          meaning: "Choose from scalar and power_law."
+          type: str
+          default: ''
+      one_halo_ktrunc_ia:
+          meaning: "This is the k (h/Mpc) scale used to truncate the IA 1-halo term to avoid the halo exclusion problem. Only use for p_*I. If set to None, no truncation is applied."
+          type: real or None
+          default: 4.0
+      two_halo_ktrunc_ia:
+          meaning: "This is the k (h/Mpc) scale used to truncate the IA 2-halo term at small scales to avoid double-counting of the 1-halo term. Only use for p_*I and if fortuna is True. If set to None, no truncation is applied."
+          type: real or None
+          default: 6.0
+      one_halo_ktrunc:
+          meaning: "This is the k (h/Mpc) scale used to truncate the 1-halo at very large scales. If set to None, no truncation is applied."
+          type: real or None
+          default: 0.1
+      two_halo_ktrunc:
+          meaning: "This is the k (h/Mpc) scale used to truncate the 2-halo at smaller scales. If set to None, no truncation is applied."
+          type: real or None
+          default: 2.0
+      hod_section_name:
+          meaning: "Section name for HOD outputs."
+          type: str
+          default: 'hod'
+      hod_section_name_ia:
+          meaning: "Section name for IA HOD outputs."
+          type: str
+          default: 'ia'
+      hod_section_name_ia_1:
+          meaning: "Section name for IA HOD outputs, if split_ia == True."
+          type: str
+          default: 'ia_1'
+      hod_section_name_ia_2:
+          meaning: "Section name for IA HOD outputs, if split_ia == True."
+          type: str
+          default: 'ia_2'
+      output_suffix:
+          meaning: "Suffix for hod parameters and HOD outputs."
+          type: str
+          default: ''
+      output_suffix_ia:
+          meaning: "Suffix for IA parameters and IA HOD outputs."
+          type: str
+          default: ''
+      output_suffix_ia_1:
+          meaning: "Suffix for IA parameters and IA HOD outputs, if split_ia == True."
+          type: str
+          default: ''
+      output_suffix_ia_2:
+          meaning: "Suffix for IA parameters and IA HOD outputs, if split_ia == True."
+          type: str
+          default: ''
+      values_name:
+          meaning: "Section name for hod values."
+          type: str
+          default: 'hod_parameters'
+      hmcode_ingredients:
+          meaning: "Choose from mead2020, mead2020_feedback, fit_feedback and None. If not None or fit sets the ingredients to match Mead+ 2021, HMCode2020 paper. fit uses input HOD to apply baryonic feedback to the P_mm, linking the P_mm to P_gg and P_gm in a self-consistent way"
+          type: str
+          default: None
+      hod_model:
+          meaning: "Which halo model to use. See OnePower for available options."
+          type: str
+          default: 'Cacciato'
+      save_observable:
+          meaning: If true predicts the SMF/LF functions
+          type: bool
+          default: False
+      observable_section_name:
+          meaning: output section name for the observable related quantities.
+          type: str
+          default: stellar_mass_function
+      observable_h_unit:
+          meaning: units of h for the observable, valid_units are 1/h and 1/h^2
+          type: str
+          default: '1/h^2'
+      # The observables_file, nobs, zmin, zmax, nz, log10_obs_min and log10_obs_max should be provided with the _hod suffix for general HOD, _ia for single IA sample, or _ia_1 and _ia_2 for split IA sample
+      observables_file:
+          meaning: "(optional) text file containing the observable values, should contain 3 columns: z_bins, obs_min, obs_max"
+          type: str
+          default: ''
+      nobs:
+          meaning: Number of observable bins within each observable-redshift bin
+                for calculating variables in terms of the observables. Use at least 100
+                to avoid numerical issue when integrating.
+          type: int
+          default: 100
+      zmin:
+          meaning: "(optional) If no observable files are given, look for the minimum values for the redshift of each observable bin. zmin should have the same number of values as obs_min and obs_max. We assume that these are bins in both redshift and observable (boxed shaped bins in observable-redshift space)."
+          type: real or real 1D
+          default:
+      zmax:
+          meaning: "(optional) If no observable files are given, look for the maximum values for the redshift of each observable bin. zmax should have the same number of values as obs_min and obs_max. We assume that these are bins in both redshift and observable (boxed shaped bins in observable-redshift space)."
+          type: real or real 1D
+          default:
+      nz:
+          meaning: "(optional) If no observable files are given, look for nz, with zmin and zmax make the number of redshift bins for which the observable is calculated at. If we have bin edges defined the nz is the number of redshift bins in each redshift-observable box."
+          type: integer
+          default:
+      log10_obs_min:
+          meaning: "(optional) If no observable files are given, look for the minimum values for observables. If using multiple bins for the observable then provide the minimum value for each bin. We assume that these are bins in both redshift and observable (boxed shaped bins in observable-redshift space). Note this is in log10 format."
+          type: real 1D
+          default:
+      log10_obs_max:
+          meaning: "(optional) If no observable files are given, look for the maximum values for observables. If using multiple bins for the observable then provide the maximum value for each bin. We assume that these are bins in both redshift and observable (boxed shaped bins in observable-redshift space). Note this is in log10 format."
+          type: real 1D
+          default:
+      central_IA_depends_on:
+          meaning: "IA dependence. Option are halo_mass, luminosity, constant"
+          type: str
+          default: "halo_mass"
+      satellite_IA_depends_on:
+          meaning: "IA dependence. Option are halo_mass, luminosity, constant"
+          type: str
+          default: "halo_mass"
+      log_mass_min:
+          meaning: "Minimum halo mass in log10(M_sun h^-1)."
+          type: real
+          default: 9.0
+      log_mass_max:
+          meaning: "Maximum halo mass in log10(M_sun h^-1)."
+          type: real
+          default: 16.0
+      nmass:
+          meaning: "Number of log10 binned halo masses."
+          type: integer
+          default: 200
+      zmin_hmf:
+          meaning: "Minimum redshift used to calculate ingredients."
+          type: real
+          default: 0.0
+      zmax_hmf:
+          meaning: "Maximum redshift used to calculate ingredients."
+          type: real
+          default: 3.0
+      nz_hmf:
+          meaning: "Number of redshift bins."
+          type: integer
+          default: 15
+      profile_cen:
+          meaning: "type of dark matter / central galaxy profile, choose from: NFW, CoredNFW, Einasto, ... see full list:
+          https://halomod.readthedocs.io/en/latest/_autosummary/halomod.profiles.html"
+          type: str
+          default: NFW
+      profile_sat:
+          meaning: "type of satellite galaxy profile, choose from: NFW, CoredNFW, Einasto, ... see full list:
+          https://halomod.readthedocs.io/en/latest/_autosummary/halomod.profiles.html"
+          type: str
+          default: NFW
+      nk:
+          meaning: "Number of k-modes for fourier transform of the profile."
+          type: integer
+          default: 100
+      profile_value_name:
+          meaning: "Section name in values.ini for profile inputs."
+          type: str
+          default: profile_parameters
+      hmf_model:
+          meaning: "Model name for halo mass function, choose from options available in hmf package. See full list:
+          https://hmf.readthedocs.io/en/latest/_autosummary/hmf.mass_function.fitting_functions.html"
+          type: str
+          default: Tinker10
+      mdef_model:
+          meaning: "Halo mass definition, choose from options availalbe in hmf package. See full list:
+          https://hmf.readthedocs.io/en/latest/_autosummary/hmf.halos.mass_definitions.html"
+          type: str
+          default: SOMean
+      overdensity:
+          meaning: Over density threshold, only used if mdef_model!=SOVirial
+          type: float
+          default: 200.0
+      cm_model_cen:
+          meaning: "Desired c(M) relation for dark matter / central galaxies, choose from option availalbe in halomod package."
+          type: str
+          default: Duffy08
+      cm_model_sat:
+          meaning: "Desired c(M) relation for satellite galaxies, choose from option availalbe in halomod package."
+          type: str
+          default: Duffy08
+      bias_model:
+          meaning: "Model name for halo bias function, choose from options available in halomod package."
+          type: str
+          default: Tinker10
+      delta_c:
+          meaning: Critical density threshold for collapse.
+          type: float
+          default: 1.686
+
+inputs:
+    profile_value_name:
+        norm_cen:
+            meaning: Normalisation of c(M) relation for central galaxies / matter
+            type: real
+            default: 1.0
+        norm_sat:
+            meaning: Normalisation of c(M) relation for satellite galaxies
+            type: real
+            default: 1.0
+        eta_cen:
+            meaning: Halo bloating for central galaxies / matter
+            type: real
+            default: 0.0
+        eta_sat:
+            meaning: Halo bloating for satellite galaxies
+            type: real
+            default: 0.0
+    matter_power_transfer_func:
+        k_h:
+          meaning: Wavenumbers k of samples in Mpc/h.
+          type: real 1D
+          default:
+        t_k:
+          meaning: Linear transfer function at z=0.
+          type: real 1D
+          default:
+    matter_power_lin:
+        z:
+            meaning: Redshifts of samples.
+            type: real 1d
+        k_h:
+            meaning: Wavenumbers k of samples in Mpc/h.
+            type: real 1d
+        p_k:
+            meaning: Linear power spectrum at samples in (Mpc/h)^-3.
+            type: real 2d
+    matter_power_nl:
+        z:
+            meaning: Redshifts of samples.
+            type: real 1d
+        k_h:
+            meaning: Wavenumbers k of samples in Mpc/h.
+            type: real 1d
+        p_k:
+            meaning: Non-linear power spectrum at samples in (Mpc/h)^-3.
+            type: real 2d
+    growth_parameters:
+        z:
+          meaning: Redshift samples of d_z
+          type: real 1D
+          default:
+        d_z:
+          meaning: Growth factor D(z)
+          type: real 1D
+          default:
+    cosmological_parameters:
+        n_s:
+            meaning: Spectral index of the primordial power spectrum
+            type: real
+            default:
+        sigma_8:
+            meaning:  linear-theory standard deviation of matter density fluctuations in spheres of radius 8 Mpc/h, at z=0
+            type: real
+            default:
+        A_s:
+          meaning:
+          type: real
+        omega_c:
+          meaning:
+          type: real
+        omega_m:
+          meaning:
+          type: real
+        omega_b:
+          meaning:
+          type: real
+        h0:
+          meaning:
+          type: real
+        mnu:
+          meaning:
+          type: real
+        w:
+          meaning:
+          type: real
+        wa:
+          meaning:
+          type: real
+        TCMB:
+          meaning:
+          type: real
+    halo_model_parameters:
+        logT_AGN:
+          meaning:
+          type: real
+        m_b:
+          meaning:
+          type: real
+    intrinsic_alignment_parameters{_suffix}:
+        beta_cen:
+          meaning: "Intrinsic alignment slope parameter for central galaxies"
+          type: real
+        beta_sat:
+          meaning: "Intrinsic alignment slope parameter for satellite galaxies"
+          type: real
+        M_pivot:
+          meaning: "Pivot mass or luminosity for intrinsic alignment"
+          type: real
+        gamma_1h_slope:
+          meaning: "Intrinsic alignment slope parameter for 1-halo term"
+          type: real
+        gamma_1h_amplitude:
+          meaning: "Intrinsic alignment amplitude parameter for 1-halo term"
+          type: real
+        gamma_2h_amplitude:
+          meaning: "Intrinsic alignment amplitude parameter for 2-halo term"
+          type: real
+    pk_parameters:
+        poisson:
+          meaning: "Poisson function normalisation or number if function is scalar"
+          type: real
+        M_0:
+          meaning: "Characteristic mass scale"
+          type: real
+        slope:
+          meaning: "Slope of the mass dependent Poisson function"
+          type: real
+        linear_fraction_fortuna:
+          meaning: if linear_fraction_fortuna is t_eff then pk_eff = (1.-t_eff)*pnl + t_eff*plin
+          type: real
+    values_name:
+        log10_obs_norm_c:
+            meaning: the normalisation for the central observable in log10(M_sun h^-2)
+            type: real
+        log10_M_ch:
+            meaning:  Characteristic halo mass for the central observable in log10(M_sun h^-2)
+            type: real
+        g1:
+            meaning:  gamma_1 the power for M_halo<<M_ch that determines the mean observable value for centrals
+            type: real
+        g2:
+            meaning:  gamma_2 the power for M_halo>>M_ch that determines the mean observable value for centrals
+            type: real
+        sigma_log10_O_c:
+            meaning: the variance of log10 observable for central galaxies. This can in principle depend on halo mass but here we assume that it doesn't.
+            type: real
+        A_cen:
+            meaning: (optional) Assembly bias parameter, should be between -1 and 1. This parameterisation is based on arXiv:1512.03050, Hearin+ 2016 A_cen * np.fmin(n_cen, 1.0-n_cen)
+            type: real
+        norm_s:
+            meaning: Normalisation of the conditional observable function for satellites
+            type: real
+        alpha_s:
+            meaning: of the conditional observable function for satellites
+            type: real
+        beta_s:
+            meaning: of the conditional observable function for satellites
+            type: real
+        pivot:
+            meaning: log10[ϕ∗s(M)] = b0 + b1(log10 m_p)+ b2(log10 m_p)^2, m_p = M/pivot
+            type: real
+        b0:
+            meaning: log10[ϕ∗s(M)] = b0 + b1(log10 m_p)+ b2(log10 m_p)^2, m_p = M/pivot
+            type: real
+        b1:
+            meaning: log10[ϕ∗s(M)] = b0 + b1(log10 m_p)+ b2(log10 m_p)^2, m_p = M/pivot
+            type: real
+        b2:
+            meaning: log10[ϕ∗s(M)] = b0 + b1(log10 m_p)+ b2(log10 m_p)^2, m_p = M/pivot
+            type: real
+        A_sat:
+            meaning: (optional) Assembly bias parameter, should be between -1 and 1. This parameterisation is based on arXiv:1512.03050, Hearin+ 2016 delta_pop_s = A_sat * n_sat n_sat = n_sat + delta_pop_s
+            type: real
+
+outputs:
+    matter_power_nl:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    galaxy_power{_suffix_i}:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    matter_galaxy_power{_suffix_i}:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    galaxy_linear_bias{_suffix_i}:
+        bg_linear:
+          meaning:
+          type:
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    galaxy_matter_linear_bias{_suffix_i}:
+        bgm_linear:
+          meaning:
+          type:
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    intrinsic_power{_suffix_i}:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    galaxy_intrinsic_power{_suffix_i}:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    matter_intrinsic_power{_suffix_i}:
+        p_k_1h:
+          meaning:
+          type: real 2D
+        p_k_2h:
+          meaning:
+          type: real 2D
+        p_k:
+          meaning:
+          type: real 2D
+        k_h:
+          meaning:
+          type: real 1D
+        z:
+          meaning:
+          type: real 1D
+    concentration_m:
+        c:
+          meaning: concentration for centrals / matter
+          type: real 2D
+        z:
+          meaning: redshift at which c is calculated
+          type: real 1D
+        m_h:
+            type: real 1D
+            meaning: halo masses for which c is calculated, in M_sun h^-1
+    concentration_sat:
+        c:
+          meaning: concentration for satellite galaxies
+          type: real 2D
+        z:
+          meaning: redshift at which c is calculated
+          type: real 1D
+        m_h:
+            type: real 1D
+            meaning: halo masses for which c is calculated, in M_sun h^-1
+    virial_radius:
+        m_h:
+            type: real 1D
+            meaning: halo masses for which c is calculated, in M_sun h^-1
+        rvir_m:
+            type: real 1D
+            meaning: virial radius for matter (centrals), this has no z-dependence
+        rvir_sat:
+            type: real 1D
+            meaning: virial radius for satellites, this has no z-dependence
+    fourier_nfw_profile:
+        ukm:
+          meaning: Fourier transform of the normalised matter halo profile (centrals) as a functions of redshift, k and mass
+          type: real 1D
+        uksat:
+          meaning: Fourier transform of the normalised halo profile for satellites as a functions of redshift, k and mass
+          type: real 1D
+        z:
+          type: real 1D
+          meaning: redshift
+        k_h:
+          meaning: Wavenumbers k of samples in Mpc/h.
+          type: real 1D
+        m_h:
+          type: real 1D
+          meaning: halo masses, in M_sun h^-1
+    density:
+        mean_density0:
+          meaning: Mean density of universe at z=0, [Msun h^2 / Mpc**3]
+          type: real
+        rho_crit:
+          meaning: critial matter density = mean_density0/Omega_m
+          type: real
+        mean_density_z:
+          meaning: Mean density of universe at redshift z, [Msun h^2 / Mpc**3]
+          type: real 1D
+        z:
+          meaning: redshift for mean density
+          type: real 1D
+        rho_halo:
+          meaning: Mean halo density
+          type: real 1D
+    hmf:
+        dndlnmh:
+          meaning: The differential mass function in terms of natural log of m, len=len(m) [units \(h^3 Mpc^{-3}\)] dn(m)/ dln m eq1 of 1306.6721
+          type: real 1D
+        m_h:
+          meaning: Halo masses in M_sun h^-1
+          type: real 1D
+        nu:
+          meaning: halo peak
+          type: real 1D
+        neff:
+          meaning: measures the slope of the linear power spectrum evaluated at the non-linear scale for different redshifts
+          type: real 1D
+        sigma8_z:
+          meaning: linear-theory standard deviation of matter density fluctuations in spheres of radius 8 Mpc/h, at a given redshift
+          type: real 1D
+        z:
+          meaning: redshift
+          type: real 1D
+    halobias:
+        b_hb:
+          meaning: Linear halo bias
+          type: real 1D
+        m_h:
+          meaning: Halo masses in M_sun h^-1
+          type: real 1D
+        z:
+          meaning: redshift
+          type: real 1D
+    cosmological_parameters:
+        f_nu:
+          meaning: Fraction of neutrinos to total matter,  f_nu = Ω_nu /Ω_m
+          type: real
+
+    hod_section_name:
+        nbins:
+          meaning: number of observable-redshift bins
+          type: int
+        mass{_i}:
+            meaning:
+            type: real 1D
+        N_sat{_i}:
+            meaning:
+            type: real 2D
+        N_cen{_i}:
+            meaning:
+            type: real 2D
+        N_tot{_i}:
+            meaning:
+            type: real 2D
+        f_star{_i}:
+            meaning:
+            type: real 2D
+        number_density_cen{_i}:
+            meaning:
+            type: real 1D
+        number_density_sat{_i}:
+            meaning:
+            type: real 1D
+        number_density_tot{_i}:
+            meaning:
+            type: real 1D
+        central_fraction{_i}:
+            meaning:
+            type: real 1D
+        satellite_fraction{_i}:
+            meaning:
+            type: real 1D
+        average_halo_mass{_i}:
+            meaning:
+            type: real 1D
+    observable_section_name:
+        z_bin{_i}:
+            meaning:
+            type: real 1D
+        obs_val{_i}:
+            meaning:
+            type: real 1D
+        obs_func{_i}:
+            meaning: This is the observable function times ln(10) times observable. Φ(m*) m* ln(10) = 1/dlog10_m*  sum 1.0/V_max
+            type: real 2D
+        obs_val_med:
+            meaning:
+            type:
+        obs_func_med:
+            meaning:
+            type:
+        obs_func_definitionn:
+            meaning:
+            type:

--- a/structure/onepower/onepower_interface.py
+++ b/structure/onepower/onepower_interface.py
@@ -1,0 +1,1210 @@
+import numbers
+import numpy as np
+from cosmosis.datablock import names, option_section
+from scipy.interpolate import interp1d
+
+from onepower.add import UpsampledSpectra
+from onepower.bnl import HAVE_DARKEMU
+
+if HAVE_DARKEMU:
+    from onepower.bnl import NonLinearBias
+from onepower.pk import Spectra
+
+cosmo_params = names.cosmological_parameters
+
+parameters_models = {
+    'Zheng': ['log10_Mmin', 'sigma', 'log10_M0', 'log10_M1', 'alpha'],
+    'Zhai': ['log10_Mmin', 'sigma', 'log10_Msat', 'log10_Mcut', 'alpha'],
+    'Cacciato': [
+        'log10_obs_norm_c',
+        'log10_m_ch',
+        'g1',
+        'g2',
+        'sigma_log10_O_c',
+        'norm_s',
+        'pivot',
+        'alpha_s',
+        'beta_s',
+        'b0',
+        'b1',
+        'b2',
+    ],
+}
+
+poisson_parameters = {
+    'constant': ['poisson'],
+    'power_law': ['poisson', 'pivot', 'slope'],
+}
+
+
+def get_string_or_none(cosmosis_block, section, name, default):
+    """
+    A helper function to return a number or None explicitly from config files
+    or return None if no value is present.
+    """
+    if cosmosis_block.has_value(section, name):
+        value = cosmosis_block.get(section, name)
+
+        if isinstance(value, str):
+            return None if value == 'None' else value
+
+        if isinstance(value, numbers.Number):
+            return cosmosis_block.get_double(section, name, default)
+
+        raise ValueError(f"Parameter {name} must be a number, string, or 'None'")
+
+    try:
+        return cosmosis_block.get_double(section, name, default)
+    except ValueError:
+        return None
+
+
+def interpolate_in_z(input_grid, z_in, z_out, axis=0):
+    """
+    Interpolation in redshift
+    Default redshift axis is the first one.
+    """
+    f_interp = interp1d(z_in, input_grid, axis=axis)
+    return f_interp(z_out)
+
+
+def log_linear_interpolation_k(power_in, k_in, k_out, axis=1, kind='linear'):
+    """
+    log-linear interpolation for power spectra. This works well for extrapolating to higher k.
+    Ideally we want to have a different routine for interpolation (spline) and extrapolation (log-linear)
+    """
+    power_interp = interp1d(
+        np.log(k_in), np.log(power_in), axis=axis, kind=kind, fill_value='extrapolate'
+    )
+    return np.exp(power_interp(np.log(k_out)))
+
+
+def get_linear_power_spectrum(block, z_vec):
+    """
+    Reads in linear matter power spectrum and downsamples
+    """
+    k_vec = block['matter_power_lin', 'k_h']
+    z_pl = block['matter_power_lin', 'z']
+    matter_power_lin = block['matter_power_lin', 'p_k']
+    return k_vec, interpolate_in_z(matter_power_lin, z_pl, z_vec)
+
+
+def get_nonlinear_power_spectrum(block, z_vec):
+    """
+    Reads in the non-linear matter power specturm and downsamples
+    """
+    k_nl = block['matter_power_nl', 'k_h']
+    z_nl = block['matter_power_nl', 'z']
+    matter_power_nl = block['matter_power_nl', 'p_k']
+    return k_nl, interpolate_in_z(matter_power_nl, z_nl, z_vec)
+
+
+def setup_hod_settings(options, suffix):
+    """Setup HOD settings based on options."""
+    hod_settings = {}
+    if options.has_value(option_section, f'observables_file_{suffix}'):
+        hod_settings['observables_file'] = options.get_string(
+            option_section, f'observables_file_{suffix}'
+        )
+    else:
+        hod_settings['observables_file'] = None
+        hod_settings['obs_min'] = np.asarray(
+            [options[option_section, f'log10_obs_min_{suffix}']]
+        ).flatten()
+        hod_settings['obs_max'] = np.asarray(
+            [options[option_section, f'log10_obs_max_{suffix}']]
+        ).flatten()
+        hod_settings['zmin'] = np.asarray(
+            [options[option_section, f'zmin_{suffix}']]
+        ).flatten()
+        hod_settings['zmax'] = np.asarray(
+            [options[option_section, f'zmax_{suffix}']]
+        ).flatten()
+        hod_settings['nz'] = options[option_section, f'nz_{suffix}']
+    hod_settings['nobs'] = options[option_section, f'nobs_{suffix}']
+    hod_settings['observable_h_unit'] = options.get_string(
+        option_section, 'observable_h_unit', default='1/h^2'
+    ).lower()
+    return hod_settings
+
+
+def setup_hod_settings_mm(hod_settings):
+    """Setup matter-matter HOD settings based on options."""
+    hod_settings_mm = hod_settings.copy()
+    if hod_settings_mm['observables_file'] is None:
+        hod_settings_mm['obs_min'] = np.array([hod_settings['obs_min'].min()])
+        hod_settings_mm['obs_max'] = np.array([hod_settings['obs_max'].max()])
+        hod_settings_mm['zmin'] = np.array([hod_settings['zmin'].min()])
+        hod_settings_mm['zmax'] = np.array([hod_settings['zmax'].max()])
+        hod_settings_mm['nz'] = 15
+    hod_settings_mm['nobs'] = 100
+    return hod_settings_mm
+
+
+def setup_hmf_config(options):
+    """Setup function to parse options and return configuration for hmf."""
+    config_hmf = {
+        'log_mass_min': options.get_double(option_section, 'log_mass_min', default=9.0),
+        'log_mass_max': options.get_double(
+            option_section, 'log_mass_max', default=16.0
+        ),
+        'dlog10m': (
+            options.get_double(option_section, 'log_mass_max', default=16.0)
+            - options.get_double(option_section, 'log_mass_min', default=9.0)
+        )
+        / options.get_int(option_section, 'nmass', default=200),
+        'z_vec': np.linspace(
+            options.get_double(option_section, 'zmin_hmf', default=0.0),
+            options.get_double(option_section, 'zmax_hmf', default=3.0),
+            options.get_int(option_section, 'nz_hmf', default=15),
+        ),
+        'nk': options.get_int(option_section, 'nk', default=100),
+        'profile_cen': options.get_string(option_section, 'profile_cen', default='NFW'),
+        'profile_sat': options.get_string(option_section, 'profile_sat', default='NFW'),
+        'profile_value_name': options.get_string(
+            option_section, 'profile_value_name', default='profile_parameters'
+        ),
+        'hmf_model': options.get_string(
+            option_section, 'hmf_model', default='Tinker10'
+        ),
+        'mdef_model': options.get_string(
+            option_section, 'mdef_model', default='SOMean'
+        ),
+        'overdensity': options.get_double(option_section, 'overdensity', default=200.0),
+        'cm_model_cen': options.get_string(
+            option_section, 'cm_model_cen', default='Duffy08'
+        ),
+        'cm_model_sat': options.get_string(
+            option_section, 'cm_model_sat', default='Duffy08'
+        ),
+        'delta_c': options.get_double(option_section, 'delta_c', default=1.686),
+        'bias_model': options.get_string(
+            option_section, 'bias_model', default='Tinker10'
+        ),
+        'lnk_min': np.log(1e-8),
+        'lnk_max': np.log(1e8),
+        'dlnk': 0.05,  # 0.001
+    }
+    return config_hmf
+
+
+def setup_pipeline_parameters(options):
+    """Setup pipeline parameters."""
+    p_mm = options.get_bool(option_section, 'p_mm', default=False)
+    p_gg = options.get_bool(option_section, 'p_gg', default=False)
+    p_gm = options.get_bool(option_section, 'p_gm', default=False)
+    p_gI = options.get_bool(option_section, 'p_gI', default=False)
+    p_mI = options.get_bool(option_section, 'p_mI', default=False)
+    p_II = options.get_bool(option_section, 'p_II', default=False)
+    # If True, calculate the response of the halo model for the requested power spectra compared to matter power
+    # multiplies this to input non-linear matter power spectra.
+    response = options.get_bool(option_section, 'response', default=False)
+    split_ia = options.get_bool(option_section, 'split_ia', default=False)
+
+    matter = p_mm
+    galaxy = p_gg or p_gm
+    alignment = p_gI or p_mI or p_II
+
+    # Fortuna introduces a truncation of the 1-halo term at large scales to avoid the halo exclusion problem
+    # and a truncation of the NLA 2-halo term at small scales to avoid double-counting of the 1-halo term
+    # The user can change these values.
+    one_halo_ktrunc_ia = get_string_or_none(
+        options, option_section, 'one_halo_ktrunc_ia', default=4.0
+    )  # h/Mpc or None
+    two_halo_ktrunc_ia = get_string_or_none(
+        options, option_section, 'two_halo_ktrunc_ia', default=6.0
+    )  # h/Mpc or None
+    # General truncation of non-IA terms:
+    one_halo_ktrunc = get_string_or_none(
+        options, option_section, 'one_halo_ktrunc', default=0.1
+    )  # h/Mpc or None
+    two_halo_ktrunc = get_string_or_none(
+        options, option_section, 'two_halo_ktrunc', default=2.0
+    )  # h/Mpc or None
+
+    # Additional parameters
+    hmcode_ingredients = get_string_or_none(
+        options, option_section, 'hmcode_ingredients', default=None
+    )
+    nonlinear_mode = get_string_or_none(
+        options, option_section, 'nonlinear_mode', default=None
+    )
+
+    dewiggle = options.get_bool(option_section, 'dewiggle', default=False)
+    point_mass = options.get_bool(option_section, 'point_mass', default=False)
+    poisson_type = options.get_string(option_section, 'poisson_type', default='')
+
+    return (
+        p_mm,
+        p_gg,
+        p_gm,
+        p_gI,
+        p_mI,
+        p_II,
+        response,
+        matter,
+        galaxy,
+        alignment,
+        split_ia,
+        one_halo_ktrunc,
+        two_halo_ktrunc,
+        one_halo_ktrunc_ia,
+        two_halo_ktrunc_ia,
+        hmcode_ingredients,
+        nonlinear_mode,
+        dewiggle,
+        point_mass,
+        poisson_type,
+    )
+
+
+def setup_hod(options, galaxy, alignment, split_ia):
+    hod_section_name = options.get_string(
+        option_section, 'hod_section_name', default='hod'
+    )
+    hod_values_name = options.get_string(
+        option_section, 'values_name', default='hod_parameters'
+    ).lower()
+
+    population_name = options.get_string(
+        option_section, 'output_suffix', default=''
+    ).lower()
+    pop_name = f'_{population_name}' if population_name else ''
+
+    if alignment:
+        central_IA = options.get_string(
+            option_section, 'central_IA_depends_on', default='halo_mass'
+        )
+        satellite_IA = options.get_string(
+            option_section, 'satellite_IA_depends_on', default='halo_mass'
+        )
+        if split_ia:
+            hod_section_name_ia_1 = options.get_string(
+                option_section, 'hod_section_name_ia_1'
+            )
+            population_name_ia_1 = options.get_string(
+                option_section, 'output_suffix_ia_1', default=''
+            ).lower()
+            pop_name_ia_1 = f'_{population_name_ia_1}' if population_name_ia_1 else ''
+
+            hod_section_name_ia_2 = options.get_string(
+                option_section, 'hod_section_name_ia_2'
+            )
+            population_name_ia_2 = options.get_string(
+                option_section, 'output_suffix_ia_2', default=''
+            ).lower()
+            pop_name_ia_2 = f'_{population_name_ia_2}' if population_name_ia_2 else ''
+        else:
+            hod_section_name_ia_1 = options.get_string(
+                option_section, 'hod_section_name_ia'
+            )
+            population_name_ia_1 = options.get_string(
+                option_section, 'output_suffix_ia', default=''
+            ).lower()
+            pop_name_ia_1 = f'_{population_name_ia_1}' if population_name_ia_1 else ''
+            hod_section_name_ia_2 = None
+            pop_name_ia_2 = None
+    else:
+        hod_section_name_ia_1 = None
+        pop_name_ia_1 = ''
+        hod_section_name_ia_2 = None
+        pop_name_ia_2 = ''
+        central_IA = None
+        satellite_IA = None
+
+    hod_model = options.get_string(option_section, 'hod_model', default='Cacciato')
+    if galaxy:
+        hod_settings = setup_hod_settings(options, 'hod')
+        hod_settings_mm = setup_hod_settings_mm(hod_settings)
+        nbins = len(hod_settings['obs_min'])
+    else:
+        hod_settings = {}
+        hod_settings_mm = {}
+        nbins = 0
+
+    if alignment:
+        if split_ia:
+            hod_settings_ia_1 = setup_hod_settings(options, 'ia_1')
+            hod_settings_ia_2 = setup_hod_settings(options, 'ia_2')
+        else:
+            hod_settings_ia_1 = setup_hod_settings(options, 'ia')
+            hod_settings_ia_2 = {}
+    else:
+        hod_settings_ia_1 = {}
+        hod_settings_ia_2 = {}
+    if options.get_bool(option_section, 'save_observable', default=False):
+        obs_settings = setup_hod_settings(options, 'smf')
+        obs_settings['save_observable'] = options.get_bool(
+            option_section, 'save_observable', default=True
+        )
+        obs_settings['observable_section_name'] = options.get_string(
+            option_section, 'observable_section_name', default='stellar_mass_function'
+        ).lower()
+    else:
+        obs_settings = {}
+        obs_settings['save_observable'] = False
+        obs_settings['observable_section_name'] = 'stellar_mass_function'
+    return (
+        hod_section_name,
+        hod_values_name,
+        pop_name,
+        hod_model,
+        hod_settings,
+        hod_settings_mm,
+        obs_settings,
+        nbins,
+        hod_settings_ia_1,
+        hod_settings_ia_2,
+        hod_section_name_ia_1,
+        hod_section_name_ia_2,
+        pop_name_ia_1,
+        pop_name_ia_2,
+        central_IA,
+        satellite_IA,
+    )
+
+
+def save_matter_results(block, power, z_vec, k_vec):
+    """Save matter results to the block."""
+    mass = power.mass
+    mean_density0 = power.mean_density0
+    mean_density_z = power.mean_density_z
+    rho_crit = power.mean_density0 / block[cosmo_params, 'omega_m']
+    rho_halo = power.rho_halo
+
+    dndlnm = power.dndlnm
+    halo_bias = power.halo_bias
+    nu = power.nu
+    neff = power.neff
+    sigma8_z = power.sigma8_z
+    fnu = power.fnu
+
+    u_dm_cen = power.u_dm
+    u_dm_sat = power.u_sat
+
+    conc_cen = power.conc_cen
+    conc_sat = power.conc_sat
+    r_s_cen = power.r_s_cen
+    r_s_sat = power.r_s_sat
+
+    rvir_cen = power.rvir_cen
+    rvir_sat = power.rvir_sat
+
+    # TODO: Clean these up. Put more of them into the same folder
+    block.put_grid('concentration_m', 'z', z_vec, 'm_h', mass, 'c', conc_cen)
+    block.put_grid('concentration_sat', 'z', z_vec, 'm_h', mass, 'c', conc_sat)
+    block.put_grid('nfw_scale_radius_m', 'z', z_vec, 'm_h', mass, 'rs', r_s_cen)
+    block.put_grid('nfw_scale_radius_sat', 'z', z_vec, 'm_h', mass, 'rs', r_s_sat)
+
+    block.put_double_array_1d('virial_radius', 'm_h', mass)
+    # rvir doesn't change with z, hence no z-dimension
+    block.put_double_array_1d('virial_radius', 'rvir_m', rvir_cen[0])
+    block.put_double_array_1d('virial_radius', 'rvir_sat', rvir_sat[0])
+
+    block.put_double_array_1d('fourier_nfw_profile', 'z', z_vec)
+    block.put_double_array_1d('fourier_nfw_profile', 'm_h', mass)
+    block.put_double_array_1d('fourier_nfw_profile', 'k_h', k_vec)
+    block.put_double_array_nd('fourier_nfw_profile', 'ukm', u_dm_cen)
+    block.put_double_array_nd('fourier_nfw_profile', 'uksat', u_dm_sat)
+
+    # Density
+    block['density', 'mean_density0'] = mean_density0
+    block['density', 'rho_crit'] = rho_crit
+    block.put_double_array_1d('density', 'mean_density_z', mean_density_z)
+    block.put_double_array_1d('density', 'rho_halo', rho_halo)
+    block.put_double_array_1d('density', 'z', z_vec)
+
+    # Halo mass function
+    block.put_grid('hmf', 'z', z_vec, 'm_h', mass, 'dndlnmh', dndlnm)
+    block.put_grid('hmf', 'z', z_vec, 'm_h', mass, 'nu', nu)
+    block.put_double_array_1d('hmf', 'neff', neff)
+    block.put_double_array_1d('hmf', 'sigma8_z', sigma8_z)
+
+    # Linear halo bias
+    block.put_grid('halobias', 'z', z_vec, 'm_h', mass, 'b_hb', halo_bias)
+
+    # Fraction of neutrinos to total matter, f_nu = Ω_nu /Ω_m
+    block[cosmo_params, 'fnu'] = fnu
+
+
+def save_hod_results(block, power, z_vec, hod_section_name, hod_settings):
+    """Save HOD results to the block."""
+    mass = power.mass
+    N_cen = power.hod.hod_cen
+    N_sat = power.hod.hod_sat
+    N_tot = power.hod.hod
+    numdens_cen = power.hod.number_density_cen
+    numdens_sat = power.hod.number_density_sat
+    numdens_tot = power.hod.number_density
+    fraction_c = power.hod.f_c
+    fraction_s = power.hod.f_s
+    mass_avg = power.mass_avg
+    f_star = power.fstar
+
+    hod_bins = N_cen.shape[0]
+    block.put_int(hod_section_name, 'nbins', hod_bins)
+    for nb in range(hod_bins):
+        suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+        block.put_grid(
+            hod_section_name,
+            f'z{suffix}',
+            z_vec,
+            f'mass{suffix}',
+            mass,
+            f'N_sat{suffix}',
+            N_sat[nb],
+        )
+        block.put_grid(
+            hod_section_name,
+            f'z{suffix}',
+            z_vec,
+            f'mass{suffix}',
+            mass,
+            f'N_cen{suffix}',
+            N_cen[nb],
+        )
+        block.put_grid(
+            hod_section_name,
+            f'z{suffix}',
+            z_vec,
+            f'mass{suffix}',
+            mass,
+            f'N_tot{suffix}',
+            N_tot[nb],
+        )
+        block.put_grid(
+            hod_section_name,
+            f'z{suffix}',
+            z_vec,
+            f'mass{suffix}',
+            mass,
+            f'f_star{suffix}',
+            f_star[nb],
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'number_density_cen{suffix}', numdens_cen[nb]
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'number_density_sat{suffix}', numdens_sat[nb]
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'number_density_tot{suffix}', numdens_tot[nb]
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'central_fraction{suffix}', fraction_c[nb]
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'satellite_fraction{suffix}', fraction_s[nb]
+        )
+        block.put_double_array_1d(
+            hod_section_name, f'average_halo_mass{suffix}', mass_avg[nb]
+        )
+    return hod_bins
+
+
+def save_obs_results(block, power, observable_section_name, obs_settings):
+    obs_func = power.obs_func
+    obs_func_c = power.obs_func_cen
+    obs_func_s = power.obs_func_sat
+    obs_z = power.obs_func_z
+    obs_range = power.obs_func_obs
+    obs_bins = obs_range.shape[0]
+
+    block.put(observable_section_name, 'obs_func_definition', 'obs_func * obs * ln(10)')
+    for nb in range(obs_bins):
+        suffix_obs = f'_{nb + 1}'
+        if np.all(
+            np.array(
+                [
+                    obs_settings['obs_min'].size,
+                    obs_settings['obs_max'].size,
+                    obs_settings['zmin'].size,
+                    obs_settings['zmax'].size,
+                    obs_settings['nz'],
+                ]
+            )
+            == 1
+        ):
+            block.put_double_array_1d(
+                observable_section_name, f'obs_val{suffix_obs}', np.squeeze(obs_range)
+            )
+            block.put_double_array_1d(
+                observable_section_name, f'obs_func{suffix_obs}', np.squeeze(obs_func)
+            )
+            block.put_double_array_1d(
+                observable_section_name,
+                f'obs_func_c{suffix_obs}',
+                np.squeeze(obs_func_c),
+            )
+            block.put_double_array_1d(
+                observable_section_name,
+                f'obs_func_s{suffix_obs}',
+                np.squeeze(obs_func_s),
+            )
+        else:
+            block.put_grid(
+                observable_section_name,
+                f'z_bin{suffix_obs}',
+                obs_z[nb],
+                f'obs_val{suffix_obs}',
+                obs_range[nb, 0, :],
+                f'obs_func{suffix_obs}',
+                obs_func[nb],
+            )
+            block.put_grid(
+                observable_section_name,
+                f'z_bin{suffix_obs}',
+                obs_z[nb],
+                f'obs_val{suffix_obs}',
+                obs_range[nb, 0, :],
+                f'obs_func_c{suffix_obs}',
+                obs_func_c[nb],
+            )
+            block.put_grid(
+                observable_section_name,
+                f'z_bin{suffix_obs}',
+                obs_z[nb],
+                f'obs_val{suffix_obs}',
+                obs_range[nb, 0, :],
+                f'obs_func_s{suffix_obs}',
+                obs_func_s[nb],
+            )
+
+
+def save_pk_to_grid(block, z_vec, k_vec, base_name, suffix, pk_1h, pk_2h, pk_tot):
+    """Save P(k) to the block."""
+    section_name = f'{base_name}{suffix}'
+    block.put_grid(section_name, 'z', z_vec, 'k_h', k_vec, 'p_k_1h', pk_1h)
+    block.put_grid(section_name, 'z', z_vec, 'k_h', k_vec, 'p_k_2h', pk_2h)
+    block.put_grid(section_name, 'z', z_vec, 'k_h', k_vec, 'p_k', pk_tot)
+
+
+def setup(options):
+    (
+        p_mm,
+        p_gg,
+        p_gm,
+        p_gI,
+        p_mI,
+        p_II,
+        response,
+        matter,
+        galaxy,
+        alignment,
+        split_ia,
+        one_halo_ktrunc,
+        two_halo_ktrunc,
+        one_halo_ktrunc_ia,
+        two_halo_ktrunc_ia,
+        hmcode_ingredients,
+        nonlinear_mode,
+        dewiggle,
+        point_mass,
+        poisson_type,
+    ) = setup_pipeline_parameters(options)
+
+    (
+        hod_section_name,
+        hod_values_name,
+        pop_name,
+        hod_model,
+        hod_settings,
+        hod_settings_mm,
+        obs_settings,
+        nbins,
+        hod_settings_ia_1,
+        hod_settings_ia_2,
+        hod_section_name_ia_1,
+        hod_section_name_ia_2,
+        pop_name_ia_1,
+        pop_name_ia_2,
+        central_IA,
+        satellite_IA,
+    ) = setup_hod(options, galaxy, alignment, split_ia)
+
+    # hmf config
+    config_hmf = setup_hmf_config(options)
+
+    if nonlinear_mode == 'bnl' and not HAVE_DARKEMU:
+        raise ImportError('Dark Emulator is required for BNL mode!')
+
+    if nonlinear_mode == 'bnl':
+        cached_bnl = {
+            'num_calls': 0,
+            'cached_bnl': None,
+            'update_bnl': options[option_section, 'update_bnl'],
+        }
+    else:
+        cached_bnl = None
+
+    config_hmf['power'] = Spectra()
+
+    return (
+        p_mm,
+        p_gg,
+        p_gm,
+        p_gI,
+        p_mI,
+        p_II,
+        response,
+        matter,
+        galaxy,
+        alignment,
+        split_ia,
+        one_halo_ktrunc,
+        two_halo_ktrunc,
+        one_halo_ktrunc_ia,
+        two_halo_ktrunc_ia,
+        hod_section_name,
+        hmcode_ingredients,
+        nonlinear_mode,
+        dewiggle,
+        point_mass,
+        poisson_type,
+        pop_name,
+        hod_model,
+        hod_settings,
+        hod_settings_mm,
+        obs_settings,
+        hod_values_name,
+        config_hmf,
+        cached_bnl,
+        central_IA,
+        satellite_IA,
+        nbins,
+        hod_settings_ia_1,
+        hod_settings_ia_2,
+        hod_section_name_ia_1,
+        hod_section_name_ia_2,
+        pop_name_ia_1,
+        pop_name_ia_2,
+    )
+
+
+def execute(block, config):
+    """Execute function to compute power spectra based on configuration."""
+    (
+        p_mm,
+        p_gg,
+        p_gm,
+        p_gI,
+        p_mI,
+        p_II,
+        response,
+        matter,
+        galaxy,
+        alignment,
+        split_ia,
+        one_halo_ktrunc,
+        two_halo_ktrunc,
+        one_halo_ktrunc_ia,
+        two_halo_ktrunc_ia,
+        hod_section_name,
+        hmcode_ingredients,
+        nonlinear_mode,
+        dewiggle,
+        point_mass,
+        poisson_type,
+        pop_name,
+        hod_model,
+        hod_settings,
+        hod_settings_mm,
+        obs_settings,
+        hod_values_name,
+        config_hmf,
+        cached_bnl,
+        central_IA,
+        satellite_IA,
+        nbins,
+        hod_settings_ia_1,
+        hod_settings_ia_2,
+        hod_section_name_ia_1,
+        hod_section_name_ia_2,
+        pop_name_ia_1,
+        pop_name_ia_2,
+    ) = config
+
+    hod_params = {}
+
+    # Power spectrum transfer function used to update the transfer function in hmf
+    transfer_k = block['matter_power_transfer_func', 'k_h']
+    transfer_func = block['matter_power_transfer_func', 't_k']
+    growth_z = block['growth_parameters', 'z']
+    growth_func = block['growth_parameters', 'd_z']
+
+    z_vec = config_hmf['z_vec']
+
+    # Load the linear power spectrum and growth factor
+    k_vec_original, plin_original = get_linear_power_spectrum(block, z_vec)
+    k_vec = np.logspace(
+        np.log10(k_vec_original[0]), np.log10(k_vec_original[-1]), num=config_hmf['nk']
+    )  # , endpoint=False)
+    z_vec_original = block.get_double_array_1d('matter_power_lin', 'z')
+
+    # If hmf and input k_vec to match!
+    # config_hmf['lnk_min'] = np.log(k_vec_original[0])
+    # config_hmf['lnk_max'] = np.log(k_vec_original[-1])
+    # config_hmf['dlnk'] = (config_hmf['lnk_max'] - config_hmf['lnk_min']) / config_hmf['nk']
+
+    plin = log_linear_interpolation_k(plin_original, k_vec_original, k_vec)
+
+    power_kwargs = {
+        'matter_power_lin': plin,
+        'hmcode_ingredients': hmcode_ingredients,
+        'nonlinear_mode': nonlinear_mode,
+        'dewiggle': dewiggle,
+        'k_vec': k_vec,
+        'z_vec': config_hmf['z_vec'],
+        'lnk_min': config_hmf['lnk_min'],
+        'lnk_max': config_hmf['lnk_max'],
+        'dlnk': config_hmf['dlnk'],
+        'Mmin': config_hmf['log_mass_min'],
+        'Mmax': config_hmf['log_mass_max'],
+        'dlog10m': config_hmf['dlog10m'],
+        'mdef_model': config_hmf['mdef_model'],
+        'hmf_model': config_hmf['hmf_model'],
+        'bias_model': config_hmf['bias_model'],
+        'halo_profile_model_dm': config_hmf['profile_cen'],
+        'halo_concentration_model_dm': config_hmf['cm_model_cen'],
+        'halo_profile_model_sat': config_hmf['profile_sat'],
+        'halo_concentration_model_sat': config_hmf['cm_model_sat'],
+        'transfer_model': 'FromArray',
+        'transfer_params': {'k': transfer_k, 'T': transfer_func},
+        'growth_model': 'FromArray',
+        'growth_params': {'z': growth_z, 'd': growth_func},
+        'norm_cen': block.get_double(
+            config_hmf['profile_value_name'], 'norm_cen', default=1.0
+        ),
+        'norm_sat': block.get_double(
+            config_hmf['profile_value_name'], 'norm_sat', default=1.0
+        ),
+        'eta_cen': block.get_double(
+            config_hmf['profile_value_name'], 'eta_cen', default=0.0
+        ),
+        'eta_sat': block.get_double(
+            config_hmf['profile_value_name'], 'eta_sat', default=0.0
+        ),
+        'overdensity': config_hmf['overdensity'],
+        'delta_c': config_hmf['delta_c'],
+        'one_halo_ktrunc': one_halo_ktrunc,
+        'two_halo_ktrunc': two_halo_ktrunc,
+        'omega_c': block[cosmo_params, 'omega_c'],
+        'omega_b': block[cosmo_params, 'omega_b'],
+        'h0': block[cosmo_params, 'h0'],
+        'n_s': block[cosmo_params, 'n_s'],
+        'sigma_8': block[cosmo_params, 'sigma_8'],
+        'm_nu': block[cosmo_params, 'mnu'],
+        'w0': block[cosmo_params, 'w'],
+        'wa': block[cosmo_params, 'wa'],
+        'tcmb': block.get_double(cosmo_params, 'TCMB', default=2.7255),
+        'log10T_AGN': block['halo_model_parameters', 'logT_AGN'],
+        'mb': 10.0 ** block.get_double('halo_model_parameters', 'm_b', default=13.87),
+    }
+
+    if nonlinear_mode == 'bnl':
+        num_calls = cached_bnl['num_calls']
+        update_bnl = cached_bnl['update_bnl']
+
+        if num_calls % update_bnl == 0:
+            bnl = NonLinearBias(
+                mass=10
+                ** np.arange(
+                    config_hmf['log_mass_min'],
+                    config_hmf['log_mass_max'],
+                    config_hmf['dlog10m'],
+                ),
+                z_vec=z_vec,
+                k_vec=k_vec,
+                h0=block[cosmo_params, 'h0'],
+                A_s=block[cosmo_params, 'A_s'],
+                omega_b=block[cosmo_params, 'omega_b'],
+                omega_c=block[cosmo_params, 'omega_c'],
+                omega_lambda=1.0 - block[cosmo_params, 'omega_m'],
+                n_s=block[cosmo_params, 'n_s'],
+                w0=block[cosmo_params, 'w'],
+                z_dep=False,
+            )
+
+            beta_interp = bnl.bnl
+            cached_bnl['cached_bnl'] = beta_interp
+        else:
+            beta_interp = cached_bnl['cached_bnl']
+
+        cached_bnl['num_calls'] = num_calls + 1
+
+        power_kwargs.update(
+            {
+                'beta_nl': beta_interp,
+            }
+        )
+
+    if response or nonlinear_mode == 'fortuna':
+        k_nl, p_nl = get_nonlinear_power_spectrum(block, z_vec)
+        pk_mm_in = log_linear_interpolation_k(p_nl, k_nl, k_vec)
+        power_kwargs.update({'matter_power_nl': pk_mm_in, 'response': response})
+    else:
+        pk_mm_in = None
+
+    if galaxy or alignment:
+        poisson_params = {}
+        for param in poisson_parameters[poisson_type]:
+            if not block.has_value('pk_parameters', param):
+                raise Exception(
+                    f'Error: parameter {param} is needed for the requested poisson model: {poisson_type}'
+                )
+            poisson_params[param] = get_string_or_none(
+                block, 'pk_parameters', param, default=None
+            )
+
+        hod_params['A_cen'] = (
+            block[hod_values_name, 'A_cen']
+            if block.has_value(hod_values_name, 'A_cen')
+            else None
+        )
+        hod_params['A_sat'] = (
+            block[hod_values_name, 'A_sat']
+            if block.has_value(hod_values_name, 'A_sat')
+            else None
+        )
+        hod_parameters = parameters_models[hod_model]
+        # Dinamically load required HOD parameters given the model and number of bins!
+        for param in hod_parameters:
+            if hod_model == 'Cacciato':
+                param_bin = param
+                if not block.has_value(hod_values_name, param_bin):
+                    raise Exception(
+                        f'Error: parameter {param} is needed for the requested hod model: {hod_model}'
+                    )
+                hod_params[param] = block[hod_values_name, param_bin]
+            else:
+                param_list = []
+                for nb in range(nbins):
+                    suffix = f'_{nb + 1}' if nbins != 1 else ''
+                    param_bin = f'{param}{suffix}'
+                    if not block.has_value(hod_values_name, param_bin):
+                        raise Exception(
+                            f'Error: parameter {param} is needed for the requested hod model: {hod_model}'
+                        )
+                    param_list.append(block[hod_values_name, param_bin])
+                hod_params[param] = np.array(param_list)
+
+        power_kwargs.update(
+            {
+                'poisson_model': poisson_type,
+                'poisson_params': poisson_params,
+                'pointmass': point_mass,
+                'hod_model': hod_model,
+                'hod_params': hod_params,
+                'hod_settings': hod_settings,
+                'obs_settings': obs_settings,
+                'compute_observable': obs_settings['save_observable'],
+                'hod_settings_mm': hod_settings_mm,
+            }
+        )
+
+    # TO-DO: for aligments at least we need to split the calculation in red/blue and add here!
+
+    if alignment:
+        align_params = {}
+        if central_IA == 'halo_mass':
+            align_params.update(
+                {
+                    'beta_sat': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_1}', 'beta_sat'
+                    ],
+                    'mpivot_sat': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_1}', 'M_pivot'
+                    ],
+                }
+            )
+        else:
+            align_params.update(
+                {
+                    'beta_sat': None,
+                    'mpivot_sat': None,
+                }
+            )
+        if satellite_IA == 'halo_mass':
+            align_params.update(
+                {
+                    'beta_cen': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_1}', 'beta'
+                    ],
+                    'mpivot_cen': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_1}', 'M_pivot'
+                    ],
+                }
+            )
+        else:
+            align_params.update(
+                {
+                    'beta_cen': None,
+                    'mpivot_cen': None,
+                }
+            )
+        align_params.update(
+            {
+                'nmass': 5,
+                'n_hankel': 350,
+                'nk': 10,
+                'ell_max': 6,
+                'gamma_1h_slope': block[
+                    f'intrinsic_alignment_parameters{pop_name_ia_1}',
+                    'gamma_1h_radial_slope',
+                ],
+                'gamma_1h_amplitude': block[
+                    f'intrinsic_alignment_parameters{pop_name_ia_1}',
+                    'gamma_1h_amplitude',
+                ],
+                'gamma_2h_amplitude': block[
+                    f'intrinsic_alignment_parameters{pop_name_ia_1}',
+                    'gamma_2h_amplitude',
+                ],
+            }
+        )
+        power_kwargs.update(
+            {
+                'align_params': align_params,
+                'one_halo_ktrunc_ia': one_halo_ktrunc_ia,
+                'two_halo_ktrunc_ia': two_halo_ktrunc_ia,
+                't_eff': block.get_double(
+                    'pk_parameters', 'linear_fraction_fortuna', default=0.0
+                ),
+            }
+        )
+        if split_ia:
+            align_params_2 = align_params.copy()
+            if central_IA == 'halo_mass':
+                align_params_2.update(
+                    {
+                        'beta_sat': block[
+                            f'intrinsic_alignment_parameters{pop_name_ia_2}', 'beta_sat'
+                        ],
+                        'mpivot_sat': block[
+                            f'intrinsic_alignment_parameters{pop_name_ia_2}', 'M_pivot'
+                        ],
+                    }
+                )
+            else:
+                align_params_2.update(
+                    {
+                        'beta_sat': None,
+                        'mpivot_sat': None,
+                    }
+                )
+            if satellite_IA == 'halo_mass':
+                align_params_2.update(
+                    {
+                        'beta_cen': block[
+                            f'intrinsic_alignment_parameters{pop_name_ia_2}', 'beta'
+                        ],
+                        'mpivot_cen': block[
+                            f'intrinsic_alignment_parameters{pop_name_ia_2}', 'M_pivot'
+                        ],
+                    }
+                )
+            else:
+                align_params_2.update(
+                    {
+                        'beta_cen': None,
+                        'mpivot_cen': None,
+                    }
+                )
+            align_params_2.update(
+                {
+                    'gamma_1h_slope': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_2}',
+                        'gamma_1h_radial_slope',
+                    ],
+                    'gamma_1h_amplitude': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_2}',
+                        'gamma_1h_amplitude',
+                    ],
+                    'gamma_2h_amplitude': block[
+                        f'intrinsic_alignment_parameters{pop_name_ia_2}',
+                        'gamma_2h_amplitude',
+                    ],
+                }
+            )
+
+    hod = not (matter and not galaxy)
+    # power = Spectra(**power_kwargs)
+    power = config_hmf['power']
+    power.update(**power_kwargs)
+
+    results = UpsampledSpectra(
+        z=z_vec_original,
+        k=k_vec_original,
+        fraction_z=None,
+        fraction=None,
+        model=power,
+        model_1_params=power_kwargs,
+        model_2_params=None,
+    )
+
+    save_matter_results(block, power, z_vec, k_vec)
+
+    if hod:
+        hod_bins = save_hod_results(block, power, z_vec, hod_section_name, hod_settings)
+        if power.obs_func is not None and obs_settings['save_observable']:
+            save_obs_results(
+                block, power, obs_settings['observable_section_name'], obs_settings
+            )
+
+    z_out = z_vec_original
+    k_out = k_vec_original
+    if p_mm or response:
+        results.results(['mm'], ['1h', '2h', 'tot'])
+        pk_mm_1h = results.power_spectrum_mm.pk_1h
+        pk_mm_2h = results.power_spectrum_mm.pk_2h
+        pk_mm = results.power_spectrum_mm.pk_tot
+        if not response:
+            block.put_grid(
+                'matter_power_nl', 'z', z_out, 'k_h', k_out, 'p_k_1h', pk_mm_1h[0]
+            )
+            block.put_grid(
+                'matter_power_nl', 'z', z_out, 'k_h', k_out, 'p_k_2h', pk_mm_2h[0]
+            )
+            block.put_grid('matter_power_nl', 'z', z_out, 'k_h', k_out, 'p_k', pk_mm[0])
+    else:
+        pk_mm = None
+
+    if p_gg:
+        results.results(['gg'], ['1h', '2h', 'tot'])
+        pk_gg_1h = results.power_spectrum_gg.pk_1h
+        pk_gg_2h = results.power_spectrum_gg.pk_2h
+        pk_gg = results.power_spectrum_gg.pk_tot
+        bg_linear = power.power_spectrum_gg.galaxy_linear_bias
+        for nb in range(hod_bins):
+            suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+            save_pk_to_grid(
+                block,
+                z_out,
+                k_out,
+                'galaxy_power',
+                suffix,
+                pk_gg_1h[nb],
+                pk_gg_2h[nb],
+                pk_gg[nb],
+            )
+            block.put_grid(
+                f'galaxy_linear_bias{suffix}',
+                'z',
+                z_vec,
+                'k_h',
+                k_vec,
+                'bg_linear',
+                bg_linear[nb],
+            )
+
+    if p_gm:
+        results.results(['gm'], ['1h', '2h', 'tot'])
+        pk_gm_1h = results.power_spectrum_gm.pk_1h
+        pk_gm_2h = results.power_spectrum_gm.pk_2h
+        pk_gm = results.power_spectrum_gm.pk_tot
+        bgm_linear = power.power_spectrum_gm.galaxy_linear_bias
+        for nb in range(hod_bins):
+            suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+            save_pk_to_grid(
+                block,
+                z_out,
+                k_out,
+                'matter_galaxy_power',
+                suffix,
+                pk_gm_1h[nb],
+                pk_gm_2h[nb],
+                pk_gm[nb],
+            )
+            block.put_grid(
+                f'galaxy_matter_linear_bias{suffix}',
+                'z',
+                z_vec,
+                'k_h',
+                k_vec,
+                'bgm_linear',
+                bgm_linear[nb],
+            )
+
+    if alignment:
+        power.update(hod_settings=hod_settings_ia_1)
+        hod_bins = save_hod_results(
+            block, power, z_vec, hod_section_name_ia_1, hod_settings_ia_1
+        )
+
+        if split_ia:
+            model_2_params = {
+                'hod_settings': hod_settings_ia_2,
+                'align_params': align_params_2,
+            }
+            results = UpsampledSpectra(
+                z=z_vec_original,
+                k=k_vec_original,
+                fraction_z=z_vec_original,
+                fraction=np.ones_like(z_vec_original),
+                model=power,
+                model_1_params=power_kwargs,
+                model_2_params=model_2_params,
+            )
+
+        if p_II:
+            results.results(['ii'], ['1h', '2h', 'tot'])
+            pk_II_1h = results.power_spectrum_ii.pk_1h
+            pk_II_2h = results.power_spectrum_ii.pk_2h
+            pk_II = results.power_spectrum_ii.pk_tot
+            for nb in range(hod_bins):
+                suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+                save_pk_to_grid(
+                    block,
+                    z_out,
+                    k_out,
+                    'intrinsic_power',
+                    suffix,
+                    pk_II_1h[nb],
+                    pk_II_2h[nb],
+                    pk_II[nb],
+                )
+
+        if p_gI:
+            results.results(['gi'], ['1h', '2h', 'tot'])
+            pk_gI_1h = results.power_spectrum_gi.pk_1h
+            pk_gI_2h = results.power_spectrum_gi.pk_2h
+            pk_gI = results.power_spectrum_gi.pk_tot
+            for nb in range(hod_bins):
+                suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+                save_pk_to_grid(
+                    block,
+                    z_out,
+                    k_out,
+                    'galaxy_intrinsic_power',
+                    suffix,
+                    pk_gI_1h[nb],
+                    pk_gI_2h[nb],
+                    pk_gI[nb],
+                )
+
+        if p_mI:
+            results.results(['mi'], ['1h', '2h', 'tot'])
+            pk_mI_1h = results.power_spectrum_mi.pk_1h
+            pk_mI_2h = results.power_spectrum_mi.pk_2h
+            pk_mI = results.power_spectrum_mi.pk_tot
+            for nb in range(hod_bins):
+                suffix = f'_{nb + 1}' if hod_bins != 1 else ''
+                save_pk_to_grid(
+                    block,
+                    z_out,
+                    k_out,
+                    'matter_intrinsic_power',
+                    suffix,
+                    pk_mI_1h[nb],
+                    pk_mI_2h[nb],
+                    pk_mI[nb],
+                )
+
+    config_hmf['power'] = power
+    return 0
+
+
+def cleanup(config):
+    # Usually python modules do not need to do anything here.
+    # We just leave it in out of pedantic completeness.
+    pass

--- a/structure/projection_1d/project_1d.py
+++ b/structure/projection_1d/project_1d.py
@@ -147,7 +147,7 @@ def execute(block, config):
         cosmo_model_run = Flatw0waCDM(
             H0=block[names.cosmological_parameters, 'hubble'],
             Ob0=block[names.cosmological_parameters, 'omega_b'],
-            Om0=block[names.cosmological_parametersarams, 'omega_m'],
+            Om0=block[names.cosmological_parameters, 'omega_m'],
             m_nu=[0, 0, block[names.cosmological_parameters, 'mnu']],
             Tcmb0=tcmb, w0=block[names.cosmological_parameters, 'w'],
             wa=block[names.cosmological_parameters, 'wa']


### PR DESCRIPTION
This PR adds the interface to onepower package to cosmosis-standard-library. So far we have only provided the interface in the onepower repo. 

Not sure if the onepower should be added to the install requirements for cosmosis/cosmosis-standard-library, as I think the install should be optional, but I can totally see complaints about importing it.