### PR TITLE
fix: [PLANCK2018]  arm64 support

### DIFF
--- a/likelihood/planck2018/plc-3.0/Makefile
+++ b/likelihood/planck2018/plc-3.0/Makefile
@@ -176,10 +176,10 @@ endif
 else
 DEFINES = $(DEFINESLINUX) $(DEFINESCOMMON)
 ifndef CM64
-CM64 = -m64
+CM64 = -march=native
 endif
 ifndef FM64
-FM64 = -m64
+FM64 = -march=native
 endif
 endif
 

--- a/likelihood/planck2018/plc-3.0/waf_tools/mbits.py
+++ b/likelihood/planck2018/plc-3.0/waf_tools/mbits.py
@@ -25,7 +25,7 @@ def configure(ctx):
     if ctx.options.m32:    
       mopt += ["-arch", "i386"]    
   else:
-    mopt = ["-m64"]
+    mopt = ["-march=native"]
     if ctx.options.m32:
       mopt = ["-m32"]
       

--- a/likelihood/planck2018/plc-3.0/waf_tools/try_ifort.py
+++ b/likelihood/planck2018/plc-3.0/waf_tools/try_ifort.py
@@ -170,8 +170,8 @@ def gfortran_conf(ctx):
       ctx.env.append_value('FCFLAGS','-m32')
       mopt = ["-m32"]
     else:
-      ctx.env.append_value('FCFLAGS','-m64')
-      mopt = ["-m64"]
+      ctx.env.append_value('FCFLAGS','-march=native')
+      mopt = ["-march=native"]
   else:
     ctx.env.append_value('FCFLAGS',ctx.env.mopt)
   ctx.start_msg("Check gfortran version") 


### PR DESCRIPTION
## Summary

The Planck 2018 likelihood (plc-3.0) build system hardcodes `-m64` in three
build files, which is x86-64 specific and fails on arm64 systems (e.g. NVIDIA
DGX Spark).

Replaces `-m64` with `-march=native` in:
- `Makefile` — `CM64` and `FM64` defaults
- `waf_tools/mbits.py` — waf C compiler flag
- `waf_tools/try_ifort.py` — gfortran flag

`-march=native` targets the host architecture, preserving x86-64 behavior
while enabling arm64 compilation.

## Test plan
- [x] Build plc-3.0 on arm64 (NVIDIA DGX Spark)
- [ ] Build plc-3.0 on x86-64 (regression check)
